### PR TITLE
Replace Kernel#returning with Object#tap

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,7 +1,7 @@
 class << ActiveRecord::Base
   def belongs_to_with_deleted(association_id, options = {})
     with_deleted = options.delete :with_deleted
-    returning belongs_to_without_deleted(association_id, options) do
+    belongs_to_without_deleted(association_id, options).tap do
       if with_deleted
         reflection = reflect_on_association(association_id)
         association_accessor_methods(reflection,            Caboose::Acts::BelongsToWithDeletedAssociation)
@@ -13,7 +13,7 @@ class << ActiveRecord::Base
   
   def has_many_without_deleted(association_id, options = {}, &extension)
     with_deleted = options.delete :with_deleted
-    returning has_many_with_deleted(association_id, options, &extension) do
+    has_many_with_deleted(association_id, options, &extension).tap do
       if options[:through] && !with_deleted
         reflection = reflect_on_association(association_id)
         collection_reader_method(reflection, Caboose::Acts::HasManyThroughWithoutDeletedAssociation)


### PR DESCRIPTION
In Rails 2.3.10 (and I assume others), this plugin causes a deprecation warning:

```
DEPRECATION WARNING: Kernel#returning has been deprecated in favor of Object#tap. (called from has_many at vendor/plugins/acts_as_paranoid/init.rb:16)
```

This pull request replaces the two calls to Kernel#returning with calls to Object#tap. I actually don't understand why either of these methods needs to be used at all (it seems like you could execute the code in the block and then return the belongs_to... or has_many... call). But since I don't completely understand the code, I thought I'd just change the method call as the deprecation warning calls for.
