### PR TITLE
Support under rails4.2

### DIFF
--- a/lib/acts_as_paranoid/validations.rb
+++ b/lib/acts_as_paranoid/validations.rb
@@ -11,10 +11,18 @@ module ActsAsParanoid
         finder_class = find_finder_class_for(record)
         table = finder_class.arel_table
 
-        coder = record.class.type_for_attribute(attribute.to_s)
+        if record.class.respond_to?(:type_for_attribute)
+          coder = record.class.type_for_attribute(attribute.to_s)
+        else
+          coder = record.class.serialized_attributes[attribute.to_s]
+        end
 
         if value && coder
-          value = coder.type_cast_for_database value
+          if coder.respond_to?(:type_cast_for_database)
+            value = coder.type_cast_for_database value
+          else
+            value = coder.dump value
+          end
         end
 
         relation = build_relation(finder_class, table, attribute, value)

--- a/lib/acts_as_paranoid/version.rb
+++ b/lib/acts_as_paranoid/version.rb
@@ -1,3 +1,3 @@
 module ActsAsParanoid
-  VERSION = "0.5.0.beta1"
+  VERSION = "0.5.0.beta2"
 end


### PR DESCRIPTION
Hi,

I was test acts_as_paranoid gem on some rails version.
https://github.com/ActsAsParanoid/acts_as_paranoid/commit/115f7623975d407b1023476ba81e43ea28f8eaba support rails 4.0.x version.
https://github.com/ActsAsParanoid/acts_as_paranoid/commit/6142210585e3f88af344620f9672d7d5bf7345be support rails 4.1.x version.
https://github.com/ActsAsParanoid/acts_as_paranoid/commit/eef6a4f3fe2014ea2c515c55b035e2952c211bb5 support rails 4.2.x but don't suport rails4.1.x or 4.0.x version.

Because `ActiveRecord::ModelSchema#type_for_attribute` and `ActiveRecord::ModelSchema#type_cast_for_database` method can use after this commit(https://github.com/rails/rails/commit/c93dbfef).

![2014-11-16 0 56 50](https://cloud.githubusercontent.com/assets/536118/5058242/7bbf40b0-6d2b-11e4-8342-ad0c9d66edda.png)

And I want to use this version on xxxx.gemspecs like `gem 'acts_as_paranoid`, '> 0.5.0.beta2'`. So bump version up to 0.5.0.beta2:)
