### PR TITLE
Fix build

### DIFF
--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rdoc"
-  spec.add_development_dependency "minitest", "~> 5.4"
+  spec.add_development_dependency "minitest", ">= 4.0", "<= 6.0"
 end

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rdoc"
-  spec.add_development_dependency "minitest", "~> 4.0"
+  spec.add_development_dependency "minitest", "~> 5.4"
 end

--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -13,6 +13,7 @@ module ActsAsParanoid
         result = belongs_to_without_deleted(target, scope, options)
 
         if with_deleted
+          result.values.last.options[:with_deleted] = with_deleted
           unless method_defined? "#{target}_with_unscoped"
             class_eval <<-RUBY, __FILE__, __LINE__
               def #{target}_with_unscoped(*args)

--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -13,7 +13,12 @@ module ActsAsParanoid
         result = belongs_to_without_deleted(target, scope, options)
 
         if with_deleted
-          result.values.last.options[:with_deleted] = with_deleted
+          if result.is_a? Hash
+            result.values.last.options[:with_deleted] = with_deleted
+          else
+            result.options[:with_deleted] = with_deleted
+          end
+
           unless method_defined? "#{target}_with_unscoped"
             class_eval <<-RUBY, __FILE__, __LINE__
               def #{target}_with_unscoped(*args)

--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -13,7 +13,6 @@ module ActsAsParanoid
         result = belongs_to_without_deleted(target, scope, options)
 
         if with_deleted
-          result[:with_deleted] = with_deleted
           unless method_defined? "#{target}_with_unscoped"
             class_eval <<-RUBY, __FILE__, __LINE__
               def #{target}_with_unscoped(*args)

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -74,7 +74,7 @@ module ActsAsParanoid
     protected
 
       def without_paranoid_default_scope
-        scope = self.all.unscoped
+        scope = self.all
         scope.where_values.delete(paranoid_default_scope_sql)
 
         scope

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -75,7 +75,13 @@ module ActsAsParanoid
 
       def without_paranoid_default_scope
         scope = self.all
-        scope.where_values.delete(paranoid_default_scope_sql)
+        if scope.where_values.include? paranoid_default_scope_sql
+          # ActiveRecord 4.1
+          scope.where_values.delete(paranoid_default_scope_sql)
+        else
+          scope = scope.with_default_scope
+          scope.where_values.delete(paranoid_default_scope_sql)
+        end
 
         scope
       end

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -148,7 +148,7 @@ module ActsAsParanoid
         # We can only recover by window if both parent and dependant have a
         # paranoid column type of :time.
         if self.class.paranoid_column_type == :time && klass.paranoid_column_type == :time
-          scope = scope.merge(klass.deleted_inside_time_window(paranoid_value, window))
+          scope = scope.deleted_inside_time_window(paranoid_value, window)
         end
 
         scope.each do |object|

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -89,7 +89,7 @@ module ActsAsParanoid
       self.send(self.class.paranoid_column)
     end
 
-    def destroy!
+    def destroy_fully!
       with_transaction_returning_status do
         run_callbacks :destroy do
           destroy_dependent_associations!
@@ -101,7 +101,7 @@ module ActsAsParanoid
       end
     end
 
-    def destroy
+    def destroy!
       if !deleted?
         with_transaction_returning_status do
           run_callbacks :destroy do
@@ -112,8 +112,12 @@ module ActsAsParanoid
           end
         end
       else
-        destroy!
+        destroy_fully!
       end
+    end
+
+    def destroy
+      destroy!
     end
 
     def recover(options={})

--- a/lib/acts_as_paranoid/validations.rb
+++ b/lib/acts_as_paranoid/validations.rb
@@ -11,10 +11,11 @@ module ActsAsParanoid
         finder_class = find_finder_class_for(record)
         table = finder_class.arel_table
 
-        coder = record.class.type_for_attribute(attribute.to_s)
+        # TODO: Use record.class.column_types[attribute.to_s].coder ?
+        coder = record.class.column_types[attribute.to_s]
 
         if value && coder
-          value = coder.type_cast_for_database value
+          value = coder.type_cast_for_write value
         end
 
         relation = build_relation(finder_class, table, attribute, value)

--- a/lib/acts_as_paranoid/validations.rb
+++ b/lib/acts_as_paranoid/validations.rb
@@ -15,7 +15,11 @@ module ActsAsParanoid
         coder = record.class.column_types[attribute.to_s]
 
         if value && coder
-          value = coder.type_cast_for_write value
+          value = if coder.respond_to? :type_cast_for_database
+                    coder.type_cast_for_database value
+                  else
+                    coder.type_cast_for_write value
+                  end
         end
 
         relation = build_relation(finder_class, table, attribute, value)

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -83,19 +83,19 @@ class AssociationsTest < ParanoidBaseTest
   end
 
   def test_belongs_to_options
-    paranoid_time = ParanoidHasManyDependant.reflections[:paranoid_time]
+    paranoid_time = ParanoidHasManyDependant.reflections.with_indifferent_access[:paranoid_time]
     assert_equal :belongs_to, paranoid_time.macro
     assert_nil paranoid_time.options[:with_deleted]
   end
 
   def test_belongs_to_with_deleted_options
-    paranoid_time_with_deleted = ParanoidHasManyDependant.reflections[:paranoid_time_with_deleted]
+    paranoid_time_with_deleted = ParanoidHasManyDependant.reflections.with_indifferent_access[:paranoid_time_with_deleted]
     assert_equal :belongs_to, paranoid_time_with_deleted.macro
     assert paranoid_time_with_deleted.options[:with_deleted]
   end
 
   def test_belongs_to_polymorphic_with_deleted_options
-    paranoid_time_polymorphic_with_deleted = ParanoidHasManyDependant.reflections[:paranoid_time_polymorphic_with_deleted]
+    paranoid_time_polymorphic_with_deleted = ParanoidHasManyDependant.reflections.with_indifferent_access[:paranoid_time_polymorphic_with_deleted]
     assert_equal :belongs_to, paranoid_time_polymorphic_with_deleted.macro
     assert paranoid_time_polymorphic_with_deleted.options[:with_deleted]
   end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -2,8 +2,6 @@ require 'test_helper'
 
 class AssociationsTest < ParanoidBaseTest
   def test_removal_with_associations
-    # This test shows that the current implementation doesn't handle
-    # assciation deletion correctly (when hard deleting via parent-object)
     paranoid_company_1 = ParanoidDestroyCompany.create! :name => "ParanoidDestroyCompany #1"
     paranoid_company_2 = ParanoidDeleteCompany.create! :name => "ParanoidDestroyCompany #1"
     paranoid_company_1.paranoid_products.create! :name => "ParanoidProduct #1"
@@ -19,13 +17,19 @@ class AssociationsTest < ParanoidBaseTest
     assert_equal 1, ParanoidDestroyCompany.with_deleted.count
     assert_equal 2, ParanoidProduct.with_deleted.count
 
-    ParanoidDestroyCompany.with_deleted.first.destroy!
+    ParanoidDestroyCompany.with_deleted.first.destroy
     assert_equal 0, ParanoidDestroyCompany.count
     assert_equal 1, ParanoidProduct.count
     assert_equal 0, ParanoidDestroyCompany.with_deleted.count
     assert_equal 1, ParanoidProduct.with_deleted.count
 
-    ParanoidDeleteCompany.with_deleted.first.destroy!
+    ParanoidDeleteCompany.first.destroy
+    assert_equal 0, ParanoidDeleteCompany.count
+    assert_equal 0, ParanoidProduct.count
+    assert_equal 1, ParanoidDeleteCompany.with_deleted.count
+    assert_equal 1, ParanoidProduct.with_deleted.count
+
+    ParanoidDeleteCompany.with_deleted.first.destroy
     assert_equal 0, ParanoidDeleteCompany.count
     assert_equal 0, ParanoidProduct.count
     assert_equal 0, ParanoidDeleteCompany.with_deleted.count

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -108,6 +108,9 @@ class AssociationsTest < ParanoidBaseTest
     child.destroy
     assert_paranoid_deletion(child)
 
+    parent.reload
+
+    assert_equal [], parent.paranoid_has_many_dependants.to_a
     assert_equal [child], parent.paranoid_has_many_dependants.with_deleted.to_a
   end
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -144,6 +144,12 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal 0, ParanoidHasOneDependant.count
     assert_equal 1, NotParanoid.count
     assert_equal 0, HasOneNotParanoid.count
+
+    assert_equal 3, ParanoidTime.with_deleted.count
+    assert_equal 4, ParanoidHasManyDependant.with_deleted.count
+    assert_equal 3, ParanoidBelongsDependant.with_deleted.count
+    assert_equal @paranoid_boolean_count + 3, ParanoidBoolean.with_deleted.count
+    assert_equal 3, ParanoidHasOneDependant.with_deleted.count
   end
 
   def test_recursive_real_removal

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -40,9 +40,9 @@ class ParanoidTest < ParanoidBaseTest
   end
 
   def test_real_removal
-    ParanoidTime.first.destroy!
+    ParanoidTime.first.destroy_fully!
     ParanoidBoolean.delete_all!("name = 'extremely paranoid' OR name = 'really paranoid'")
-    ParanoidString.first.destroy!
+    ParanoidString.first.destroy_fully!
     assert_equal 2, ParanoidTime.count
     assert_equal 1, ParanoidBoolean.count
     assert_equal 0, ParanoidString.count
@@ -155,7 +155,7 @@ class ParanoidTest < ParanoidBaseTest
   def test_recursive_real_removal
     setup_recursive_tests
 
-    @paranoid_time_object.destroy!
+    @paranoid_time_object.destroy_fully!
 
     assert_equal 0, ParanoidTime.only_deleted.count
     assert_equal 1, ParanoidHasManyDependant.only_deleted.count

--- a/test/test_default_scopes.rb
+++ b/test/test_default_scopes.rb
@@ -37,7 +37,7 @@ class MultipleDefaultScopesTest < ParanoidBaseTest
     assert_equal 0, ParanoidHuman.only_deleted.count
     assert_equal 3, ParanoidHuman.unscoped.count
 
-    ParanoidHuman.first.destroy!
+    ParanoidHuman.first.destroy_fully!
     assert_equal 1, ParanoidHuman.count
     assert_equal 1, ParanoidHuman.with_deleted.count
     assert_equal 0, ParanoidHuman.only_deleted.count

--- a/test/test_relations.rb
+++ b/test/test_relations.rb
@@ -75,7 +75,7 @@ class RelationsTest < ParanoidBaseTest
 
   def test_fake_removal_through_relation
     # destroy: through a relation.
-    ParanoidForest.rainforest.destroy(@paranoid_forest_3)
+    ParanoidForest.rainforest.destroy(@paranoid_forest_3.id)
     assert_equal 1, ParanoidForest.rainforest.count
     assert_equal 2, ParanoidForest.rainforest.with_deleted.count
     assert_equal 1, ParanoidForest.rainforest.only_deleted.count
@@ -95,8 +95,8 @@ class RelationsTest < ParanoidBaseTest
 
     # destroy: two-step through a relation
     paranoid_tree = @paranoid_forest_1.paranoid_trees.first
-    @paranoid_forest_1.paranoid_trees.order(:id).destroy(paranoid_tree)
-    @paranoid_forest_1.paranoid_trees.only_deleted.destroy(paranoid_tree)
+    @paranoid_forest_1.paranoid_trees.order(:id).destroy(paranoid_tree.id)
+    @paranoid_forest_1.paranoid_trees.only_deleted.destroy(paranoid_tree.id)
     assert_equal 1, @paranoid_forest_1.paranoid_trees(true).count
     assert_equal 1, @paranoid_forest_1.paranoid_trees(true).with_deleted.count
     assert_equal 0, @paranoid_forest_1.paranoid_trees(true).only_deleted.count


### PR DESCRIPTION
This set of commits makes acts_as_paranoid's build pass on activerecord 4.0 and 4.1.

There is one incompatible change, which is that `#destroy!` now does the same as `#destroy`. This is because AR assumes that the only potential difference is that `#destroy!` might raise an exception and calls that version in some callbacks.