### PR TITLE
Fixed bug with ambiguous columns

### DIFF
--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -38,8 +38,8 @@ module ActsAsParanoid
         deleted_after_time((time - window)).deleted_before_time((time + window))
       }
 
-      scope :deleted_after_time, lambda  { |time| where("#{paranoid_column} > ?", time) }
-      scope :deleted_before_time, lambda { |time| where("#{paranoid_column} < ?", time) }
+      scope :deleted_after_time, lambda  { |time| where("#{self.table_name}.#{paranoid_column} > ?", time) }
+      scope :deleted_before_time, lambda { |time| where("#{self.table_name}.#{paranoid_column} < ?", time) }
     end
   end
 end

--- a/lib/acts_as_paranoid/version.rb
+++ b/lib/acts_as_paranoid/version.rb
@@ -1,3 +1,3 @@
 module ActsAsParanoid
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end


### PR DESCRIPTION
Querying the `paranoid_column` when restoring associations would blow up because the table_name wasn't specified in the query for the recovery window

* also bumped up the version to v0.4.4