### PR TITLE
Added support for allow_nulls option for boolean column.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ The values shown are the defaults. While *column* can be anything (as long as it
 
 If your column type is a `string`, you can also specify which value to use when marking an object as deleted by passing `:deleted_value` (default is "deleted"). Any records with a non-matching value in this column will be treated normally (ie: not deleted).
 
+If your column type is a `boolean`, it is possible to specify `allow_nulls` option which is `true` by default. When set to `false`, entities that have `false` value in this column will be considered not deleted, and those which have `true` will be considered deleted. When `true` everything that has a not-null value will be considered deleted.
+
 ### Filtering
 
 If a record is deleted by ActsAsParanoid, it won't be retrieved when accessing the database. So, `Paranoiac.all` will **not** include the deleted_records. if you want to access them, you have 2 choices:

--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -20,6 +20,7 @@ module ActsAsParanoid
 
     self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes }
     self.paranoid_configuration.merge!({ :deleted_value => "deleted" }) if options[:column_type] == "string"
+    self.paranoid_configuration.merge!({ :allow_nulls => true }) if options[:column_type] == "boolean"
     self.paranoid_configuration.merge!(options) # user options
 
     raise ArgumentError, "'time', 'boolean' or 'string' expected for :column_type option, got #{paranoid_configuration[:column_type]}" unless ['time', 'boolean', 'string'].include? paranoid_configuration[:column_type]

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -304,8 +304,8 @@ class ParanoidTest < ParanoidBaseTest
       @paranoid_with_callback.recover
     end
 
-      assert @paranoid_with_callback.called_before_recover
-      assert @paranoid_with_callback.called_after_recover
+    assert @paranoid_with_callback.called_before_recover
+    assert @paranoid_with_callback.called_after_recover
   end
 
   def test_delete_by_multiple_id_is_paranoid
@@ -412,5 +412,45 @@ class ParanoidTest < ParanoidBaseTest
 
     paranoid_with_counter_cache.destroy_fully!
     assert_equal 0, paranoid_boolean.reload.paranoid_with_counter_caches_count
+  end
+
+  # Test boolean type columns, that are not nullable
+  def test_boolean_type_with_no_nil_value_before_destroy
+    ps = ParanoidBooleanNotNullable.create!()
+    assert_equal 1, ParanoidBooleanNotNullable.where(:id => ps).count
+  end
+
+  def test_boolean_type_with_no_nil_value_after_destroy
+    ps = ParanoidBooleanNotNullable.create!()
+    ps.destroy
+    assert_equal 0, ParanoidBooleanNotNullable.where(:id => ps).count
+  end
+
+  def test_boolean_type_with_no_nil_value_before_destroy_with_deleted
+    ps = ParanoidBooleanNotNullable.create!()
+    assert_equal 1, ParanoidBooleanNotNullable.with_deleted.where(:id => ps).count
+  end
+
+  def test_boolean_type_with_no_nil_value_after_destroy_with_deleted
+    ps = ParanoidBooleanNotNullable.create!()
+    ps.destroy
+    assert_equal 1, ParanoidBooleanNotNullable.with_deleted.where(:id => ps).count
+  end
+
+  def test_boolean_type_with_no_nil_value_before_destroy_only_deleted
+    ps = ParanoidBooleanNotNullable.create!()
+    assert_equal 0, ParanoidBooleanNotNullable.only_deleted.where(:id => ps).count
+  end
+
+  def test_boolean_type_with_no_nil_value_after_destroy_only_deleted
+    ps = ParanoidBooleanNotNullable.create!()
+    ps.destroy
+    assert_equal 1, ParanoidBooleanNotNullable.only_deleted.where(:id => ps).count
+  end
+
+  def test_boolean_type_with_no_nil_value_after_destroyed_twice
+    ps = ParanoidBooleanNotNullable.create!()
+    2.times { ps.destroy }
+    assert_equal 0, ParanoidBooleanNotNullable.with_deleted.where(:id => ps).count
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -190,6 +190,11 @@ def setup_db
       t.string    :paranoid_thing_type
       t.datetime :deleted_at
     end
+
+    create_table :paranoid_boolean_not_nullables do |t|
+      t.string :name
+      t.boolean :deleted, :boolean, :null => false, :default => false
+    end
   end
 end
 
@@ -437,3 +442,8 @@ class ParanoidSection < ActiveRecord::Base
   belongs_to :paranoid_time
   belongs_to :paranoid_thing, :polymorphic => true, :dependent => :destroy
 end
+
+class ParanoidBooleanNotNullable < ActiveRecord::Base
+  acts_as_paranoid column: 'deleted', column_type: 'boolean', allow_nulls: false
+end
+


### PR DESCRIPTION
The motivation behind this pull-request is that the default behaviour of the gem with boolean columns is not very logical. Entities which have attribute `deleted == false` are currently considered deleted (because false is not nil).

When using boolean column type it is now possible to pass `allow_nulls` options which is `true` by default. When set to `false` we check for `false` values in `deleted` column instead of nils when checking if the entities are deleted or not. 

Thus it is possible to define `deleted` column as:
```ruby
t.boolean :deleted, :boolean, null: false, default: false
```

And then in the ActiveRecord model:
```ruby
acts_as_paranoid column: 'deleted', column_type: 'boolean', allow_nulls: false
```

The default behaviour is preserved and is backwards-compatible.

This new case is fully covered with tests.