### PR TITLE
fix Default scope, use table connection for generating sql

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -41,9 +41,9 @@ module ActsAsParanoid
         if string_type_with_deleted_value?
           self.all.table[paranoid_column].eq(nil).
             or(self.all.table[paranoid_column].not_eq(paranoid_configuration[:deleted_value])).
-            to_sql
+            to_sql(self)
         else
-          self.all.table[paranoid_column].eq(nil).to_sql
+          self.all.table[paranoid_column].eq(nil).to_sql(self)
         end
       end
 


### PR DESCRIPTION
We found and issue, when `acts_as_paranoid` is used with `database_cleaner` gem and multiple database adapters like `mysql` and `postgresql`. We had the following errors
> Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '."deleted_at" IS NULL) LIMIT 1' at line 1: SELECT  `users`.* FROM `users` WHERE `users`.`id` = 42 AND ("users"."deleted_at" IS NULL) LIMIT 1