### PR TITLE
Fix deprecation warning using alias_method_chain

### DIFF
--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -3,7 +3,8 @@ module ActsAsParanoid
     def self.included(base)
       base.extend ClassMethods
       class << base
-        alias_method_chain :belongs_to, :deleted
+        alias_method :belongs_to_without_deleted, :belongs_to
+        alias_method :belongs_to, :belongs_to_with_deleted
       end
     end
 

--- a/lib/acts_as_paranoid/preloader_association.rb
+++ b/lib/acts_as_paranoid/preloader_association.rb
@@ -8,7 +8,8 @@ module ActsAsParanoid
           scope
         end
 
-        alias_method_chain :build_scope, :deleted
+        alias_method :build_scope_without_deleted, :build_scope
+        alias_method :build_scope, :build_scope_with_deleted
       end
     end
   end


### PR DESCRIPTION
`alias_method_chain` is deprecated in favor of `prepend`. For simplicity
I've used two `alias_method` to avoid using `alias_method_chain` so
everything should be working in the same way.

Ideally would be better to use `prepend` instead of two `alias_method`, just wanted to remove the warning. Feel free to use it if you want.
