### PR TITLE
Replaces alias_method_chain with Module.prepend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,11 @@ before_install:
 
 script: "bundle exec rake test"
 rvm:
-  - 1.9.3
   - 2.0.0
-  - 2.1.9
+  - 2.1.10
   - 2.2.5
   - 2.3.1
   - ruby-head
-  - jruby
   - jruby-9.1.0.0
   - rbx
 gemfile:
@@ -24,11 +22,10 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: rbx
-    - rvm: jruby
     - rvm: jruby-9.1.0.0
   fast_finish: true
   exclude:
-    - rvm: 1.9.3
+    - rvm: 2.1.10
       gemfile: gemfiles/active_record_50.gemfile
     - rvm: 2.0.0
       gemfile: gemfiles/active_record_50.gemfile

--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -1,16 +1,15 @@
 module ActsAsParanoid
   module Associations
     def self.included(base)
-      base.extend ClassMethods
       class << base
-        alias_method_chain :belongs_to, :deleted
+        prepend(ClassMethods)
       end
     end
 
     module ClassMethods
-      def belongs_to_with_deleted(target, scope = nil, options = {})
+      def belongs_to(target, scope = nil, options = {})
         with_deleted = (scope.is_a?(Hash) ? scope : options).delete(:with_deleted)
-        result = belongs_to_without_deleted(target, scope, options)
+        result = super(target, scope, options)
 
         if with_deleted
           if result.is_a? Hash
@@ -19,16 +18,15 @@ module ActsAsParanoid
             result.options[:with_deleted] = with_deleted
           end
 
-          unless method_defined? "#{target}_with_unscoped"
-            class_eval <<-RUBY, __FILE__, __LINE__
-              def #{target}_with_unscoped(*args)
-                association = association(:#{target})
-                return nil if association.options[:polymorphic] && association.klass.nil?
-                return #{target}_without_unscoped(*args) unless association.klass.paranoid?
-                association.klass.with_deleted.scoping { #{target}_without_unscoped(*args) }
-              end
-              alias_method_chain :#{target}, :unscoped
-            RUBY
+          # Grab unbound instance method from super above
+          original_method = instance_method(target.to_sym)
+
+          # Define new accessor that honors the paranoid logic
+          define_method(target) do |*args|
+            association = association(target.to_sym)
+            return nil if association.options[:polymorphic] && association.klass.nil?
+            return original_method.bind(self).call(*args) unless association.klass.paranoid?
+            association.klass.with_deleted.scoping { original_method.bind(self).call(*args) }
           end
         end
 

--- a/lib/acts_as_paranoid/preloader_association.rb
+++ b/lib/acts_as_paranoid/preloader_association.rb
@@ -2,13 +2,15 @@ module ActsAsParanoid
   module PreloaderAssociation
     def self.included(base)
       base.class_eval do
-        def build_scope_with_deleted
-          scope = build_scope_without_deleted
-          scope = scope.with_deleted if options[:with_deleted] && klass.respond_to?(:with_deleted)
-          scope
-        end
+        prepend(PrependedMethods)
+      end
+    end
 
-        alias_method_chain :build_scope, :deleted
+    module PrependedMethods
+      def build_scope
+        scope = super
+        scope = scope.with_deleted if options[:with_deleted] && klass.respond_to?(:with_deleted)
+        scope
       end
     end
   end

--- a/lib/acts_as_paranoid/version.rb
+++ b/lib/acts_as_paranoid/version.rb
@@ -1,3 +1,3 @@
 module ActsAsParanoid
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
- Rails deprecated alias_method_chain in Rails 5 and recommends using Module.prepend instead.
- Commit refactors implementation to use prepend instead.
- Commit replaces class_eval with define_method in associations.rb, See: http://tenderlovemaking.com/2013/03/03/dynamic_method_definitions.html
- Commit requires ruby 2.0+ to support Module.prepend, removes support for ruby 1.9 in travis
- Commit bumps version to 0.6.0
