### PR TITLE
allow set custom value on recover

### DIFF
--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -19,7 +19,7 @@ module ActsAsParanoid
 
     class_attribute :paranoid_configuration, :paranoid_column_reference
 
-    self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes }
+    self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes, :recovery_value => nil }
     self.paranoid_configuration.merge!({ :deleted_value => "deleted" }) if options[:column_type] == "string"
     self.paranoid_configuration.merge!({ :allow_nulls => true }) if options[:column_type] == "boolean"
     self.paranoid_configuration.merge!(options) # user options

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -144,7 +144,7 @@ module ActsAsParanoid
         run_callbacks :recover do
           recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
 
-          self.paranoid_value = nil
+          self.paranoid_value = self.class.paranoid_configuration[:recovery_value]
           self.save
         end
       end


### PR DESCRIPTION
When paranoid column set as NOT NULL, recovery fail with error(e.g. "Mysql2::Error: Column 'is_del' cannot be null" ).
This PR allow set custom value with option "recovery_value" for acts_as_paranoid