### PR TITLE
Improved test_should_validate_without_deleted test, added refute

### DIFF
--- a/test/test_validations.rb
+++ b/test/test_validations.rb
@@ -13,6 +13,7 @@ class ValidatesUniquenessTest < ParanoidBaseTest
 
   def test_should_validate_without_deleted
     ParanoidBoolean.new(:name => 'paranoid').tap do |record|
+      refute record.valid?
       ParanoidBoolean.first.destroy
       assert record.valid?
       ParanoidBoolean.only_deleted.first.destroy!


### PR DESCRIPTION
If this test doesn't proof that the record is invalid in the first case, the validation isn't tested at all, record could be valid anyway even without destroying the objects.