### PR TITLE
Recover! method

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,22 @@ or in the recover statement
 Paranoiac.only_deleted.where("name = ?", "not dead yet").first.recover(:recovery_window => 30.seconds)
 ```
 
+### recover!
+
+You can invoke `recover!` if you wish to raise an error if the recovery fails. The error generally stems from ActiveRecord.
+
+```
+Paranoiac.only_deleted.where("name = ?", "not dead yet").first.recover!
+
+### => ActiveRecord::RecordInvalid: Validation failed: Name already exists
+```
+
+Optionally, you may also raise the error by passing `:raise_error => true` to the `recover` method. This behaves the same as `recover!`.
+
+```
+Paranoiac.only_deleted.where("name = ?", "not dead yet").first.recover(:raise_error => true)
+```
+
 ### Validation
 ActiveRecord's built-in uniqueness validation does not account for records deleted by ActsAsParanoid. If you want to check for uniqueness among non-deleted records only, use the macro `validates_as_paranoid` in your model. Then, instead of using `validates_uniqueness_of`, use `validates_uniqueness_of_without_deleted`. This will keep deleted records from counting against the uniqueness check.
 
@@ -261,6 +277,22 @@ parent.destroy
 
 child.parent #=> nil
 child.parent_including_deleted #=> Parent (it works!)
+```
+
+### Callbacks
+
+There are couple of callbacks that you may use when dealing with deletion and recovery of objects. There is `before_recover` and `after_recover` which will be
+triggered before and after the recovery of an object respectively.
+
+Default ActiveRecord callbaks such as `before_destroy` and `after_destroy` will be triggered around `.destroy!` and `.destroy_fully!`.
+
+```
+class Paranoiac < ActiveRecord::Base
+  acts_as_paranoid
+
+  before_recover :set_counts
+  after_recover :update_logs
+end
 ```
 
 ## Caveats

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -160,7 +160,8 @@ module ActsAsParanoid
     def recover(options={})
       options = {
         :recursive => self.class.paranoid_configuration[:recover_dependent_associations],
-        :recovery_window => self.class.paranoid_configuration[:dependent_recovery_window]
+        :recovery_window => self.class.paranoid_configuration[:dependent_recovery_window],
+        :raise_error => false
       }.merge(options)
 
       self.class.transaction do
@@ -168,9 +169,19 @@ module ActsAsParanoid
           recover_dependent_associations(options[:recovery_window], options) if options[:recursive]
           increment_counters_on_associations
           self.paranoid_value = self.class.paranoid_configuration[:recovery_value]
-          self.save
+          if options[:raise_error]
+            self.save!
+          else
+            self.save
+          end
         end
       end
+    end
+
+    def recover!(options={})
+      options[:raise_error] = true
+
+      recover(options)
     end
 
     def recover_dependent_associations(window, options)

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -94,6 +94,15 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal 1, ParanoidString.count
   end
 
+  def test_recovery!
+    ParanoidBoolean.first.destroy
+    ParanoidBoolean.create(:name => 'paranoid')
+
+    assert_raise do
+      ParanoidBoolean.only_deleted.first.recover!
+    end
+  end
+
   def setup_recursive_tests
     @paranoid_time_object = ParanoidTime.first
 


### PR DESCRIPTION
* Add `recover!` method which raises error if the recovery fails
* Add tests and docs for `recover!`
* Add new section `callbacks` to Readme.md to document about the callbacks

NOTE: The test for `recover!` fails for Rails 5 for the same reason as #71 