### PR TITLE
Remove use of alias_method_chain

### DIFF
--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -28,7 +28,8 @@ module ActsAsParanoid
                 return #{target}_without_unscoped(*args) unless association.klass.paranoid?
                 association.klass.with_deleted.scoping { #{target}_without_unscoped(*args) }
               end
-              alias_method_chain :#{target}, :unscoped
+              alias_method :#{target}_without_unscoped, :#{target}
+              alias_method :#{target}, :#{target}_with_unscoped
             RUBY
           end
         end


### PR DESCRIPTION
#54 fixes two instances of `alias_method_chain` but leaves a third. This converts it using the same approach.