### PR TITLE
Rails 5 test fix

### DIFF
--- a/lib/acts_as_paranoid/validations.rb
+++ b/lib/acts_as_paranoid/validations.rb
@@ -21,9 +21,6 @@ module ActsAsParanoid
           finder_class = find_finder_class_for(record)
           table = finder_class.arel_table
 
-          coder = record.class.attribute_types[attribute.to_s]
-          value = coder.type_cast_for_schema value if value && coder
-
           relation = build_relation(finder_class, table, attribute, value)
           [Array(finder_class.primary_key), Array(record.send(:id))].transpose.each do |pk_key, pk_value|
             relation = relation.where(table[pk_key.to_sym].not_eq(pk_value))
@@ -33,7 +30,7 @@ module ActsAsParanoid
             relation = relation.where(table[scope_item].eq(record.public_send(scope_item)))
           end
 
-          if relation.where(finder_class.paranoid_default_scope).where(relation).exists?
+          if relation.where(finder_class.paranoid_default_scope).exists?(relation)
             record.errors.add(attribute, :taken, options.except(:case_sensitive, :scope).merge(:value => value))
           end
         end


### PR DESCRIPTION
Closes #71 

I'd like some guidance on this if possible. The tests are passing, but I have limited understanding of why these changes work and why the offending code was there in the first place. This PR fixes two issues with `validate_each`:

1. `type_case_for_schema` for a string simply calls `.inspect ` which returns a string _with_ quotation marks. So `build_relation` was looking for, say, "\\"paranoid\\"" rather than "paranoid".

1. Once that was sorted, `relation.where(finder_class.paranoid_default_scope).where(relation).exists?` returned `ArgumentError: Unsupported argument type`. Moving `relation` to be an argument on `exists?` fixed that.

The test for `active_record_edge` isn't working because `bundle install` is failing. `activerecord 5.2.0alpha` is looking for `areal 9.0.0.alpha` which hasn't been released yet.