### PR TITLE
Fixing a deprecation warning with alias_method_chain

### DIFF
--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -28,7 +28,8 @@ module ActsAsParanoid
                 return #{target}_without_unscoped(*args) unless association.klass.paranoid?
                 association.klass.with_deleted.scoping { #{target}_without_unscoped(*args) }
               end
-              alias_method_chain :#{target}, :unscoped
+              alias_method :#{target}_without_unscoped, :#{target}
+              alias_method :#{target}, :#{target}_with_unscoped
             RUBY
           end
         end


### PR DESCRIPTION
Previous pull requests had fixed some of these, but one was missed.  This should fix the last remnant.