### PR TITLE
Use a more generic example for the default scope test

### DIFF
--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -211,7 +211,7 @@ class ParanoidTest < ParanoidBaseTest
     child_1 = ParanoidAndroid.create
     section_1 = ParanoidSection.create(:paranoid_thing => child_1)
 
-    child_2 = ParanoidHuman.create(:gender => 'male')
+    child_2 = ParanoidHuman.create(:legs => 2)
     section_2 = ParanoidSection.create(:paranoid_thing => child_2)
 
     assert_equal section_1.paranoid_thing, child_1

--- a/test/test_default_scopes.rb
+++ b/test/test_default_scopes.rb
@@ -4,11 +4,10 @@ class MultipleDefaultScopesTest < ParanoidBaseTest
   def setup
     setup_db
 
-    # Naturally, the default scope for humans is male. Sexism++
-    ParanoidHuman.create! :gender => 'male'
-    ParanoidHuman.create! :gender => 'male'
-    ParanoidHuman.create! :gender => 'male'
-    ParanoidHuman.create! :gender => 'female'
+    ParanoidHuman.create! :legs => 2
+    ParanoidHuman.create! :legs => 2
+    ParanoidHuman.create! :legs => 2
+    ParanoidHuman.create! :legs => 1
 
     assert_equal 3, ParanoidHuman.count
     assert_equal 4, ParanoidHuman.unscoped.count

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -165,7 +165,7 @@ def setup_db
     end
 
     create_table :paranoid_humen do |t|
-      t.string   :gender
+      t.integer  :legs
       t.datetime :deleted_at
 
       timestamps t
@@ -453,7 +453,7 @@ end
 
 class ParanoidHuman < ActiveRecord::Base
   acts_as_paranoid
-  default_scope { where('gender = ?', 'male') }
+  default_scope { where('legs = ?', 2) }
 end
 
 class ParanoidAndroid < ActiveRecord::Base


### PR DESCRIPTION
Remove the sexism endorsing comment and switch to a property of humans that we start with by default.

Props to @bad6e for finding this. I just had the spare cycles to make the change.