### PR TITLE
Replace humans with polygons in the test

### DIFF
--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -211,13 +211,13 @@ class ParanoidTest < ParanoidBaseTest
     child_1 = ParanoidAndroid.create
     section_1 = ParanoidSection.create(:paranoid_thing => child_1)
 
-    child_2 = ParanoidHuman.create(:gender => 'male')
+    child_2 = ParanoidPolygon.create(:sides => 3)
     section_2 = ParanoidSection.create(:paranoid_thing => child_2)
 
     assert_equal section_1.paranoid_thing, child_1
     assert_equal section_1.paranoid_thing.class, ParanoidAndroid
     assert_equal section_2.paranoid_thing, child_2
-    assert_equal section_2.paranoid_thing.class, ParanoidHuman
+    assert_equal section_2.paranoid_thing.class, ParanoidPolygon
 
     parent = ParanoidTime.create(:name => "paranoid_parent")
     parent.paranoid_sections << section_1
@@ -226,14 +226,14 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal 4, ParanoidTime.count
     assert_equal 2, ParanoidSection.count
     assert_equal 1, ParanoidAndroid.count
-    assert_equal 1, ParanoidHuman.count
+    assert_equal 1, ParanoidPolygon.count
 
     parent.destroy
 
     assert_equal 3, ParanoidTime.count
     assert_equal 0, ParanoidSection.count
     assert_equal 0, ParanoidAndroid.count
-    assert_equal 0, ParanoidHuman.count
+    assert_equal 0, ParanoidPolygon.count
 
     parent.reload
     parent.recover
@@ -241,7 +241,7 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal 4, ParanoidTime.count
     assert_equal 2, ParanoidSection.count
     assert_equal 1, ParanoidAndroid.count
-    assert_equal 1, ParanoidHuman.count
+    assert_equal 1, ParanoidPolygon.count
   end
 
   def test_non_recursive_recovery

--- a/test/test_default_scopes.rb
+++ b/test/test_default_scopes.rb
@@ -5,48 +5,48 @@ class MultipleDefaultScopesTest < ParanoidBaseTest
     setup_db
 
     # Naturally, the default scope for humans is male. Sexism++
-    ParanoidHuman.create! :gender => 'male'
-    ParanoidHuman.create! :gender => 'male'
-    ParanoidHuman.create! :gender => 'male'
-    ParanoidHuman.create! :gender => 'female'
+    ParanoidPolygon.create! :sides => 3
+    ParanoidPolygon.create! :sides => 3
+    ParanoidPolygon.create! :sides => 3
+    ParanoidPolygon.create! :sides => 8
 
-    assert_equal 3, ParanoidHuman.count
-    assert_equal 4, ParanoidHuman.unscoped.count
+    assert_equal 3, ParanoidPolygon.count
+    assert_equal 4, ParanoidPolygon.unscoped.count
   end
 
   def test_fake_removal_with_multiple_default_scope
-    ParanoidHuman.first.destroy
-    assert_equal 2, ParanoidHuman.count
-    assert_equal 3, ParanoidHuman.with_deleted.count
-    assert_equal 1, ParanoidHuman.only_deleted.count
-    assert_equal 4, ParanoidHuman.unscoped.count
+    ParanoidPolygon.first.destroy
+    assert_equal 2, ParanoidPolygon.count
+    assert_equal 3, ParanoidPolygon.with_deleted.count
+    assert_equal 1, ParanoidPolygon.only_deleted.count
+    assert_equal 4, ParanoidPolygon.unscoped.count
 
-    ParanoidHuman.destroy_all
-    assert_equal 0, ParanoidHuman.count
-    assert_equal 3, ParanoidHuman.with_deleted.count
-    assert_equal 3, ParanoidHuman.with_deleted.count
-    assert_equal 4, ParanoidHuman.unscoped.count
+    ParanoidPolygon.destroy_all
+    assert_equal 0, ParanoidPolygon.count
+    assert_equal 3, ParanoidPolygon.with_deleted.count
+    assert_equal 3, ParanoidPolygon.with_deleted.count
+    assert_equal 4, ParanoidPolygon.unscoped.count
   end
 
   def test_real_removal_with_multiple_default_scope
     # two-step
-    ParanoidHuman.first.destroy
-    ParanoidHuman.only_deleted.first.destroy
-    assert_equal 2, ParanoidHuman.count
-    assert_equal 2, ParanoidHuman.with_deleted.count
-    assert_equal 0, ParanoidHuman.only_deleted.count
-    assert_equal 3, ParanoidHuman.unscoped.count
+    ParanoidPolygon.first.destroy
+    ParanoidPolygon.only_deleted.first.destroy
+    assert_equal 2, ParanoidPolygon.count
+    assert_equal 2, ParanoidPolygon.with_deleted.count
+    assert_equal 0, ParanoidPolygon.only_deleted.count
+    assert_equal 3, ParanoidPolygon.unscoped.count
 
-    ParanoidHuman.first.destroy_fully!
-    assert_equal 1, ParanoidHuman.count
-    assert_equal 1, ParanoidHuman.with_deleted.count
-    assert_equal 0, ParanoidHuman.only_deleted.count
-    assert_equal 2, ParanoidHuman.unscoped.count
+    ParanoidPolygon.first.destroy_fully!
+    assert_equal 1, ParanoidPolygon.count
+    assert_equal 1, ParanoidPolygon.with_deleted.count
+    assert_equal 0, ParanoidPolygon.only_deleted.count
+    assert_equal 2, ParanoidPolygon.unscoped.count
 
-    ParanoidHuman.delete_all!
-    assert_equal 0, ParanoidHuman.count
-    assert_equal 0, ParanoidHuman.with_deleted.count
-    assert_equal 0, ParanoidHuman.only_deleted.count
-    assert_equal 1, ParanoidHuman.unscoped.count
+    ParanoidPolygon.delete_all!
+    assert_equal 0, ParanoidPolygon.count
+    assert_equal 0, ParanoidPolygon.with_deleted.count
+    assert_equal 0, ParanoidPolygon.only_deleted.count
+    assert_equal 1, ParanoidPolygon.unscoped.count
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -164,8 +164,8 @@ def setup_db
       timestamps t
     end
 
-    create_table :paranoid_humen do |t|
-      t.string   :gender
+    create_table :paranoid_polygons do |t|
+      t.integer   :sides
       t.datetime :deleted_at
 
       timestamps t
@@ -451,9 +451,9 @@ class ParanoidTree < ActiveRecord::Base
   validates_presence_of :name
 end
 
-class ParanoidHuman < ActiveRecord::Base
+class ParanoidPolygon < ActiveRecord::Base
   acts_as_paranoid
-  default_scope { where('gender = ?', 'male') }
+  default_scope { where('sides = ?', 3) }
 end
 
 class ParanoidAndroid < ActiveRecord::Base


### PR DESCRIPTION
Avoids all the possible -isms when dealing with humans in favor of an object that as no feelings and is generally just drawn on a page. The default scope is the minimum number of sides required for a polygon.

Props to @bad6e for finding this and @AllPurposeName for calling me out on the ableism with the prior PR. A redo of #87 