### PR TITLE
Add warning on second destroy

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -133,6 +133,7 @@ module ActsAsParanoid
           end
         end
       else
+        warn('WARN: acts_as_paranoid FULLY DESTROY on deleted record!')
         destroy_fully!
       end
     end


### PR DESCRIPTION
Hi I was surprised to read this behaviour.

> Alternatively you can permanently delete a record by calling destroy or delete_all on the object twice.

To  #Avoid some accidentally fully destroy, I hope it show some warning to notice developer this.

```
> Paranoiac.only_deleted.first.destroy
# WARN: acts_as_paranoid FULLY DESTROY on deleted record!
```