### PR TITLE
Avoid timestamp creation deprecation messages on AR 4.2

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -193,20 +193,20 @@ def setup_db
       t.integer :parent_id
       t.datetime :deleted_at
 
-      t.timestamps
+      timestamps t
     end
 
     create_table :not_paranoid_has_many_as_parents do |t|
       t.string :name
 
-      t.timestamps
+      timestamps t
     end
 
     create_table :paranoid_has_many_as_parents do |t|
       t.string :name
       t.datetime :deleted_at
 
-      t.timestamps
+      timestamps t
     end
   end
 end


### PR DESCRIPTION
Makes test output a little cleaner.