### PR TITLE
Fix Rails 5.2 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ matrix:
     - rvm: ruby-head
     - rvm: jruby
     - rvm: jruby-9.1.8.0
-    - gemfile: gemfiles/active_record_52.gemfile
     - gemfile: gemfiles/active_record_edge.gemfile
       rvm: 2.4.4
     - gemfile: gemfiles/active_record_edge.gemfile

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -105,6 +105,13 @@ module ActsAsParanoid
       self.send(self.class.paranoid_column)
     end
 
+    # Straight from ActiveRecord 5.1!
+    def delete
+      self.class.delete(id) if persisted?
+      @destroyed = true
+      freeze
+    end
+
     def destroy_fully!
       with_transaction_returning_status do
         run_callbacks :destroy do

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -228,6 +228,9 @@ class AssociationsTest < ParanoidBaseTest
   end
 
   def test_mass_assignment_of_paranoid_column_enabled
+    if ActiveRecord::VERSION::MAJOR > 4 && ActiveRecord::VERSION::MINOR > 1
+      skip 'Creation as deleted is not supported with Rails >= 5.2'
+    end
     now = Time.now
     record = ParanoidTime.create! :name => 'Foo', :deleted_at => now
     assert_equal 'Foo', record.name


### PR DESCRIPTION
Notable differences in Rails 5.2:

* ActiveRecord 5.2 refuses to save deleted model instances. This means that things like `ParanoidFoo.create! deleted_at: 1.day.ago` will fail. I've decided to just drop support for this use case when Rails 5.2 is used. It also means you cannot change the time of deletion after the fact. I've changed the test that used this to stub `Time.now` instead.
* ActiveRecord 5.2 changes the implementation of `#delete` from the way it was in 4.2, 5.0, *and* 5.1. ActsAsParanoid now simply redefines it back.