### PR TITLE
Double tap destroys fully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pkg
 .DS_Store
 Gemfile.lock
 gemfiles/*.lock
+.idea/

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ p.destroy # does NOT delete the first record, just hides it
 Paranoiac.only_deleted.where(:id => p.id).first.destroy # deletes the first record from the database
 ```
 
+This behaviour can be disabled by setting the configuration option
+
+- `:double_tap_destroys_fully => false`
+
 ### Recovery
 
 Recovery is easy. Just invoke `recover` on it, like this:

--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -19,7 +19,7 @@ module ActsAsParanoid
 
     class_attribute :paranoid_configuration, :paranoid_column_reference
 
-    self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes, :recovery_value => nil }
+    self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes, :recovery_value => nil, double_tap_destroys_fully: true }
     self.paranoid_configuration.merge!({ :deleted_value => "deleted" }) if options[:column_type] == "string"
     self.paranoid_configuration.merge!({ :allow_nulls => true }) if options[:column_type] == "boolean"
     self.paranoid_configuration.merge!(options) # user options

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -140,7 +140,9 @@ module ActsAsParanoid
           end
         end
       else
-        destroy_fully!
+        if paranoid_configuration[:double_tap_destroys_fully]
+          destroy_fully!
+        end
       end
     end
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -437,4 +437,10 @@ class ParanoidTest < ParanoidBaseTest
     2.times { ps.destroy }
     assert_equal 0, ParanoidBooleanNotNullable.with_deleted.where(:id => ps).count
   end
+
+  def test_no_double_tap_destroys_fully
+    ps = ParanoidNoDoubleTapDestroysFully.create!()
+    2.times { ps.destroy }
+    assert_equal 1, ParanoidNoDoubleTapDestroysFully.with_deleted.where(:id => ps).count
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -208,6 +208,10 @@ def setup_db
 
       timestamps t
     end
+
+    create_table :paranoid_no_double_tap_destroys_fullies do |t|
+      t.datetime :deleted_at
+    end
   end
 end
 
@@ -254,6 +258,10 @@ class ParanoidString < ActiveRecord::Base
 end
 
 class NotParanoid < ActiveRecord::Base
+end
+
+class ParanoidNoDoubleTapDestroysFully < ActiveRecord::Base
+  acts_as_paranoid :double_tap_destroys_fully => false
 end
 
 class HasOneNotParanoid < ActiveRecord::Base


### PR DESCRIPTION
This pull request adds an option

- `double_tap_destroys_fully: false`

that disables the behaviour of calling destroy_fully on a second destroy.

The default is true (i.e. current behaviour is retained), but in a future release a breaking change may flip that (see #92).