### PR TITLE
Make paranoid_column_reference a method

### DIFF
--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -17,7 +17,7 @@ module ActsAsParanoid
   def acts_as_paranoid(options = {})
     raise ArgumentError, "Hash expected, got #{options.class.name}" if not options.is_a?(Hash) and not options.empty?
 
-    class_attribute :paranoid_configuration, :paranoid_column_reference
+    class_attribute :paranoid_configuration
 
     self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes, :recovery_value => nil }
     self.paranoid_configuration.merge!({ :deleted_value => "deleted" }) if options[:column_type] == "string"
@@ -26,7 +26,9 @@ module ActsAsParanoid
 
     raise ArgumentError, "'time', 'boolean' or 'string' expected for :column_type option, got #{paranoid_configuration[:column_type]}" unless ['time', 'boolean', 'string'].include? paranoid_configuration[:column_type]
 
-    self.paranoid_column_reference = "#{self.table_name}.#{paranoid_configuration[:column]}"
+    def self.paranoid_column_reference
+      "#{self.table_name}.#{paranoid_configuration[:column]}"
+    end
 
     return if paranoid?
 


### PR DESCRIPTION
* paranoid_column_reference is currently a class attribute which is set when a class is
loaded and the acts_as_paranoid method is invoked. A
rails model can set its table_name after it declares itself as
acts_as_paranoid.  This means that whenever paranoid_column_reference is
referenced in the gem it does not match the table_name for the model
which can cause errors

e.g.

```ruby
# Currently works
class User
  self.table_name = "Account"
  acts_as_paranoid
end
#Currently breaks
class User
  acts_as_paranoid
  self.table_name = "Account"
end
```
This change turns this attribute into a method so that it will always
match whatever the table_name is instead of it set when the class is loaded.  

This means a developer can invoke acts_as_paranoid wherever they would like in the class and if they change table_name at runtime acts_as_paranoid continues to work