### PR TITLE
Support for incrementing and decrementing counter cache columns on associated objects for ActiveRecord>=4.x

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -121,7 +121,7 @@ module ActsAsParanoid
             # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
             self.class.delete_all!(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
 
-            if ActiveRecord::VERSION::MAJOR >= 5
+            if ActiveRecord::VERSION::MAJOR >= 4
               decrement_counters_on_associations
             end
           end
@@ -141,7 +141,7 @@ module ActsAsParanoid
               # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
               self.class.delete_all(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
 
-              if ActiveRecord::VERSION::MAJOR >= 5
+              if ActiveRecord::VERSION::MAJOR >= 4
                 decrement_counters_on_associations
               end
             end

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -116,17 +116,16 @@ module ActsAsParanoid
       with_transaction_returning_status do
         run_callbacks :destroy do
           destroy_dependent_associations!
-          # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
+
           if persisted?
-            affected_row_count = self.class.delete_all!(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
+            # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
+            self.class.delete_all!(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
 
             if ActiveRecord::VERSION::MAJOR >= 5
-              decrement_counters_on_associations affected_row_count
+              decrement_counters_on_associations
             end
-            affected_row_count
-          else
-            true
           end
+
           self.paranoid_value = self.class.delete_now_value
           freeze
         end
@@ -137,19 +136,17 @@ module ActsAsParanoid
       if !deleted?
         with_transaction_returning_status do
           run_callbacks :destroy do
-            # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
-            @_trigger_destroy_callback =
-              if persisted?
-                affected_row_count = self.class.delete_all(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
 
-                if ActiveRecord::VERSION::MAJOR >= 5
-                  decrement_counters_on_associations affected_row_count
-                end
+            if persisted?
+              # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
+              self.class.delete_all(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
 
-                affected_row_count
-              else
-                true
+              if ActiveRecord::VERSION::MAJOR >= 5
+                decrement_counters_on_associations
               end
+            end
+
+            @_trigger_destroy_callback = true
 
             self.paranoid_value = self.class.delete_now_value
             self
@@ -242,25 +239,14 @@ module ActsAsParanoid
       self.send("#{self.class.paranoid_column}=", value)
     end
 
-    def decrement_counters_on_associations affected_row_count
-      if affected_row_count > 0
-        each_counter_cached_association_reflection do |assoc_reflection|
-          foreign_key = assoc_reflection.foreign_key.to_sym
-          unless destroyed_by_association && destroyed_by_association.foreign_key.to_sym == foreign_key
-            associated_object = send(assoc_reflection.name)
-            counter_cache_column = assoc_reflection.counter_cache_column
-            associated_object.class.send(:decrement_counter, counter_cache_column, associated_object.id)
-          end
-        end
-      end
-    end
+    def update_counters_on_associations method_sym
 
-    def increment_counters_on_associations
+      return unless [:decrement_counter, :increment_counter].include? method_sym
+
       each_counter_cached_association_reflection do |assoc_reflection|
-        foreign_key = assoc_reflection.foreign_key.to_sym
         associated_object = send(assoc_reflection.name)
         counter_cache_column = assoc_reflection.counter_cache_column
-        associated_object.class.send(:increment_counter, counter_cache_column, associated_object.id)
+        associated_object.class.send(method_sym, counter_cache_column, associated_object.id)
       end
     end
 
@@ -268,6 +254,14 @@ module ActsAsParanoid
       _reflections.each do |name, reflection|
         yield reflection if reflection.belongs_to? && reflection.counter_cache_column == "#{self.class.name.underscore.pluralize}_count"
       end
+    end
+
+    def increment_counters_on_associations
+        update_counters_on_associations :increment_counter
+    end
+
+    def decrement_counters_on_associations
+        update_counters_on_associations :decrement_counter
     end
   end
 end

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -443,4 +443,41 @@ class ParanoidTest < ParanoidBaseTest
     2.times { ps.destroy }
     assert_equal 1, ParanoidNoDoubleTapDestroysFully.with_deleted.where(:id => ps).count
   end
+
+  def test_decrement_counters
+    paranoid_boolean = ParanoidBoolean.create!()
+    paranoid_with_counter_cache = ParanoidWithCounterCache.create!(paranoid_boolean: paranoid_boolean)
+
+    assert_equal 1, paranoid_boolean.paranoid_with_counter_caches_count
+
+    paranoid_with_counter_cache.destroy
+
+    assert_equal 0, paranoid_boolean.paranoid_with_counter_caches_count
+  end
+
+  def test_hard_destroy_decrement_counters
+    paranoid_boolean = ParanoidBoolean.create!()
+    paranoid_with_counter_cache = ParanoidWithCounterCache.create!(paranoid_boolean: paranoid_boolean)
+
+    assert_equal 1, paranoid_boolean.paranoid_with_counter_caches_count
+
+    paranoid_with_counter_cache.destroy_fully!
+
+    assert_equal 0, paranoid_boolean.paranoid_with_counter_caches_count
+  end
+
+  def test_increment_counters
+    paranoid_boolean = ParanoidBoolean.create!()
+    paranoid_with_counter_cache = ParanoidWithCounterCache.create!(paranoid_boolean: paranoid_boolean)
+
+    assert_equal 1, paranoid_boolean.paranoid_with_counter_caches_count
+
+    paranoid_with_counter_cache.destroy
+
+    assert_equal 0, paranoid_boolean.paranoid_with_counter_caches_count
+
+    paranoid_with_counter_cache.recover
+
+    assert_equal 1, paranoid_boolean.paranoid_with_counter_caches_count
+  end
 end

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -452,7 +452,7 @@ class ParanoidTest < ParanoidBaseTest
 
     paranoid_with_counter_cache.destroy
 
-    assert_equal 0, paranoid_boolean.paranoid_with_counter_caches_count
+    assert_equal 0, paranoid_boolean.reload.paranoid_with_counter_caches_count
   end
 
   def test_hard_destroy_decrement_counters
@@ -463,7 +463,7 @@ class ParanoidTest < ParanoidBaseTest
 
     paranoid_with_counter_cache.destroy_fully!
 
-    assert_equal 0, paranoid_boolean.paranoid_with_counter_caches_count
+    assert_equal 0, paranoid_boolean.reload.paranoid_with_counter_caches_count
   end
 
   def test_increment_counters
@@ -474,10 +474,10 @@ class ParanoidTest < ParanoidBaseTest
 
     paranoid_with_counter_cache.destroy
 
-    assert_equal 0, paranoid_boolean.paranoid_with_counter_caches_count
+    assert_equal 0, paranoid_boolean.reload.paranoid_with_counter_caches_count
 
     paranoid_with_counter_cache.recover
 
-    assert_equal 1, paranoid_boolean.paranoid_with_counter_caches_count
+    assert_equal 1, paranoid_boolean.reload.paranoid_with_counter_caches_count
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -31,7 +31,7 @@ def setup_db
       t.string    :name
       t.boolean   :is_deleted
       t.integer   :paranoid_time_id
-
+      t.integer   :paranoid_with_counter_caches_count
       timestamps t
     end
 
@@ -148,7 +148,7 @@ def setup_db
       timestamps t
     end
 
-   create_table :paranoid_forests do |t|
+    create_table :paranoid_forests do |t|
       t.string   :name
       t.boolean  :rainforest
       t.datetime :deleted_at
@@ -212,6 +212,14 @@ def setup_db
     create_table :paranoid_no_double_tap_destroys_fullies do |t|
       t.datetime :deleted_at
     end
+
+    create_table :paranoid_with_counter_caches do |t|
+      t.string    :name
+      t.datetime  :deleted_at
+      t.integer   :paranoid_boolean_id
+
+      timestamps t
+    end
   end
 end
 
@@ -251,6 +259,7 @@ class ParanoidBoolean < ActiveRecord::Base
 
   belongs_to :paranoid_time
   has_one :paranoid_has_one_dependant, :dependent => :destroy
+  has_many :paranoid_with_counter_cache, :dependent => :destroy
 end
 
 class ParanoidString < ActiveRecord::Base
@@ -271,6 +280,11 @@ end
 class DoubleHasOneNotParanoid < HasOneNotParanoid
   belongs_to :paranoid_time, :with_deleted => true
   belongs_to :paranoid_time, :with_deleted => true
+end
+
+class ParanoidWithCounterCache < ActiveRecord::Base
+  acts_as_paranoid
+  belongs_to :paranoid_boolean, :counter_cache => true
 end
 
 class ParanoidHasManyDependant < ActiveRecord::Base


### PR DESCRIPTION
Hi, we came across a problem while we were developing our software which was that counter cache columns weren't being decremented when deleting an associated object and they were also not being increment when recovering an associated object. I think I managed it pretty well with help from pull request #40  . 