### PR TITLE
Fix a couple issues with counter caches

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -244,15 +244,16 @@ module ActsAsParanoid
       return unless [:decrement_counter, :increment_counter].include? method_sym
 
       each_counter_cached_association_reflection do |assoc_reflection|
-        associated_object = send(assoc_reflection.name)
-        counter_cache_column = assoc_reflection.counter_cache_column
-        associated_object.class.send(method_sym, counter_cache_column, associated_object.id)
+        if associated_object = send(assoc_reflection.name)
+          counter_cache_column = assoc_reflection.counter_cache_column
+          associated_object.class.send(method_sym, counter_cache_column, associated_object.id)
+        end
       end
     end
 
     def each_counter_cached_association_reflection
       _reflections.each do |name, reflection|
-        yield reflection if reflection.belongs_to? && reflection.counter_cache_column == "#{self.class.name.underscore.pluralize}_count"
+        yield reflection if reflection.belongs_to? && reflection.counter_cache_column
       end
     end
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -455,6 +455,23 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal 0, paranoid_boolean.reload.paranoid_with_counter_caches_count
   end
 
+  def test_decrement_custom_counters
+    paranoid_boolean = ParanoidBoolean.create!()
+    paranoid_with_custom_counter_cache = ParanoidWithCustomCounterCache.create!(paranoid_boolean: paranoid_boolean)
+
+    assert_equal 1, paranoid_boolean.custom_counter_cache
+
+    paranoid_with_custom_counter_cache.destroy
+
+    assert_equal 0, paranoid_boolean.reload.custom_counter_cache
+  end
+
+  def test_destroy_with_optional_belongs_to_and_counter_cache
+    ps = ParanoidWithCounterCacheOnOptionalBelognsTo.create!()
+    ps.destroy
+    assert_equal 1, ParanoidWithCounterCacheOnOptionalBelognsTo.only_deleted.where(:id => ps).count
+  end
+
   def test_hard_destroy_decrement_counters
     paranoid_boolean = ParanoidBoolean.create!()
     paranoid_with_counter_cache = ParanoidWithCounterCache.create!(paranoid_boolean: paranoid_boolean)
@@ -464,6 +481,17 @@ class ParanoidTest < ParanoidBaseTest
     paranoid_with_counter_cache.destroy_fully!
 
     assert_equal 0, paranoid_boolean.reload.paranoid_with_counter_caches_count
+  end
+
+  def test_hard_destroy_decrement_custom_counters
+    paranoid_boolean = ParanoidBoolean.create!()
+    paranoid_with_custom_counter_cache = ParanoidWithCustomCounterCache.create!(paranoid_boolean: paranoid_boolean)
+
+    assert_equal 1, paranoid_boolean.custom_counter_cache
+
+    paranoid_with_custom_counter_cache.destroy_fully!
+
+    assert_equal 0, paranoid_boolean.reload.custom_counter_cache
   end
 
   def test_increment_counters
@@ -479,5 +507,20 @@ class ParanoidTest < ParanoidBaseTest
     paranoid_with_counter_cache.recover
 
     assert_equal 1, paranoid_boolean.reload.paranoid_with_counter_caches_count
+  end
+
+  def test_increment_custom_counters
+    paranoid_boolean = ParanoidBoolean.create!()
+    paranoid_with_custom_counter_cache = ParanoidWithCustomCounterCache.create!(paranoid_boolean: paranoid_boolean)
+
+    assert_equal 1, paranoid_boolean.custom_counter_cache
+
+    paranoid_with_custom_counter_cache.destroy
+
+    assert_equal 0, paranoid_boolean.reload.custom_counter_cache
+
+    paranoid_with_custom_counter_cache.recover
+
+    assert_equal 1, paranoid_boolean.reload.custom_counter_cache
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,6 +32,7 @@ def setup_db
       t.boolean   :is_deleted
       t.integer   :paranoid_time_id
       t.integer   :paranoid_with_counter_caches_count
+      t.integer   :custom_counter_cache
       timestamps t
     end
 
@@ -260,6 +261,7 @@ class ParanoidBoolean < ActiveRecord::Base
   belongs_to :paranoid_time
   has_one :paranoid_has_one_dependant, :dependent => :destroy
   has_many :paranoid_with_counter_cache, :dependent => :destroy
+  has_many :paranoid_with_custom_counter_cache, :dependent => :destroy
 end
 
 class ParanoidString < ActiveRecord::Base
@@ -285,6 +287,24 @@ end
 class ParanoidWithCounterCache < ActiveRecord::Base
   acts_as_paranoid
   belongs_to :paranoid_boolean, :counter_cache => true
+end
+
+class ParanoidWithCustomCounterCache < ActiveRecord::Base
+  self.table_name = "paranoid_with_counter_caches"
+
+  acts_as_paranoid
+  belongs_to :paranoid_boolean, counter_cache: :custom_counter_cache
+end
+
+class ParanoidWithCounterCacheOnOptionalBelognsTo < ActiveRecord::Base
+  self.table_name = "paranoid_with_counter_caches"
+
+  acts_as_paranoid
+  if ActiveRecord::VERSION::MAJOR < 5
+    belongs_to :paranoid_boolean, counter_cache: true, required: false
+  else
+    belongs_to :paranoid_boolean, counter_cache: true, optional: true
+  end
 end
 
 class ParanoidHasManyDependant < ActiveRecord::Base


### PR DESCRIPTION
This change fixes two issues with using counter caches. One is related to being able to specify a custom counter cache column, and the other is using a counter cache on an optional belongs_to association.