### PR TITLE
Remove superflous version check

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -121,9 +121,7 @@ module ActsAsParanoid
             # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
             self.class.delete_all!(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
 
-            if ActiveRecord::VERSION::MAJOR >= 4
-              decrement_counters_on_associations
-            end
+            decrement_counters_on_associations
           end
 
           self.paranoid_value = self.class.delete_now_value
@@ -141,9 +139,7 @@ module ActsAsParanoid
               # Handle composite keys, otherwise we would just use `self.class.primary_key.to_sym => self.id`.
               self.class.delete_all(Hash[[Array(self.class.primary_key), Array(self.id)].transpose])
 
-              if ActiveRecord::VERSION::MAJOR >= 4
-                decrement_counters_on_associations
-              end
+              decrement_counters_on_associations
             end
 
             @_trigger_destroy_callback = true


### PR DESCRIPTION
Version 4.2 or higher of ActiveRecord is required, so no need to check for versions of 4 or higher.