### PR TITLE
Allow model to set table_name after acts_as_paranoid macro

### DIFF
--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -17,7 +17,7 @@ module ActsAsParanoid
   def acts_as_paranoid(options = {})
     raise ArgumentError, "Hash expected, got #{options.class.name}" if not options.is_a?(Hash) and not options.empty?
 
-    class_attribute :paranoid_configuration, :paranoid_column_reference
+    class_attribute :paranoid_configuration
 
     self.paranoid_configuration = { :column => "deleted_at", :column_type => "time", :recover_dependent_associations => true, :dependent_recovery_window => 2.minutes, :recovery_value => nil, double_tap_destroys_fully: true }
     self.paranoid_configuration.merge!({ :deleted_value => "deleted" }) if options[:column_type] == "string"
@@ -26,7 +26,9 @@ module ActsAsParanoid
 
     raise ArgumentError, "'time', 'boolean' or 'string' expected for :column_type option, got #{paranoid_configuration[:column_type]}" unless ['time', 'boolean', 'string'].include? paranoid_configuration[:column_type]
 
-    self.paranoid_column_reference = "#{self.table_name}.#{paranoid_configuration[:column]}"
+    def self.paranoid_column_reference
+      "#{self.table_name}.#{paranoid_configuration[:column]}"
+    end
 
     return if paranoid?
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -523,4 +523,8 @@ class ParanoidTest < ParanoidBaseTest
 
     assert_equal 1, paranoid_boolean.reload.custom_counter_cache
   end
+
+  def test_explicitly_setting_table_name_after_acts_as_paranoid_macro
+    assert_equal "explicit_table.deleted_at", ParanoidWithExplicitTableNameAfterMacro.paranoid_column_reference
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -513,3 +513,7 @@ class ParanoidBooleanNotNullable < ActiveRecord::Base
   acts_as_paranoid column: 'deleted', column_type: 'boolean', allow_nulls: false
 end
 
+class ParanoidWithExplicitTableNameAfterMacro < ActiveRecord::Base
+  acts_as_paranoid
+  self.table_name = "explicit_table"
+end


### PR DESCRIPTION
I originally opened #117  without tests, and since then have deleted my fork, so reforked and opened this PR with a spec @mvz 

Thought about also asserting that `ParanoidWithExplicitTableNameAfterMacro.only_deleted` is working since that's how I found the error, but I think this test is clearer what exactly we're testing. Lemme know what ya think

* paranoid_column_reference is currently a class attribute which is set
    when a class is loaded and the acts_as_paranoid method is invoked. A
    rails model can set its table_name after it declares itself as
    acts_as_paranoid. This means that whenever paranoid_column_reference is
    referenced in the gem it does not match the table_name for the model
    which can cause errors.

* e.g. ActsAsParanoid::Core#only_deleted references
    `paranoid_column_reference` so in the below examples when we call this
    method on the paranoid class it tries to look up a table_name matching
    the model name. If the table doesn't exist a sql error is raised because
    the table does not exist. If the table does exist (maybe you're moving
    data to a new table and deprecating old ones) you'll end up returning
    the old records.

* This change makes it a method so that it returns whatever the current
    value of table_name is

```ruby 
  # current incorrect behavior
    class User
      acts_as_paranoid
      self.table_name = "Account"
    end

    User.paranoid_column_reference
    => "user.deleted_at"
```
```ruby
   # new correct behavior
    class User
      acts_as_paranoid
      self.table_name = "Account"
    end

    User.paranoid_column_reference
    => "account.deleted_at"
```