### PR TITLE
Adds guard clause to prevent recovery of non-deleted records

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -158,6 +158,7 @@ module ActsAsParanoid
     alias_method :destroy, :destroy!
 
     def recover(options={})
+      return if !self.deleted?
       options = {
         :recursive => self.class.paranoid_configuration[:recover_dependent_associations],
         :recovery_window => self.class.paranoid_configuration[:dependent_recovery_window]

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -312,6 +312,14 @@ class ParanoidTest < ParanoidBaseTest
     assert @paranoid_with_callback.called_after_recover
   end
 
+  def test_recovery_callbacks_without_destroy
+    @paranoid_with_callback = ParanoidWithCallback.first
+    @paranoid_with_callback.recover
+
+    assert_nil @paranoid_with_callback.called_before_recover
+    assert_nil @paranoid_with_callback.called_after_recover
+  end
+
   def test_delete_by_multiple_id_is_paranoid
     model_a = ParanoidBelongsDependant.create
     model_b = ParanoidBelongsDependant.create


### PR DESCRIPTION
Currently all records respond to the `.recover` method, including
records that are not deleted. This change ensures that calling `recover`
on un-deleted records will no-op. We also added specs to verify this
behavior.

Co-authored-by: Valerie Woolard <valerie.woolard@gmail.com>