### PR TITLE
Add predicate to check if record was soft deleted or hard deleted

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -109,7 +109,6 @@ module ActsAsParanoid
     def delete
       self.class.delete(id) if persisted?
       stale_paranoid_value
-      @destroyed = true
       freeze
     end
 
@@ -126,6 +125,7 @@ module ActsAsParanoid
           end
 
           stale_paranoid_value
+          @destroyed = true
           freeze
         end
       end
@@ -231,7 +231,7 @@ module ActsAsParanoid
     end
 
     def deleted?
-      !if self.class.string_type_with_deleted_value?
+      @destroyed || !if self.class.string_type_with_deleted_value?
         paranoid_value != self.class.delete_now_value || paranoid_value.nil?
       elsif self.class.boolean_type_not_nullable?
         paranoid_value == false
@@ -241,6 +241,12 @@ module ActsAsParanoid
     end
 
     alias_method :destroyed?, :deleted?
+
+    def deleted_fully?
+      @destroyed
+    end
+
+    alias_method :destroyed_fully?, :deleted_fully?
 
     private
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -307,6 +307,43 @@ class ParanoidTest < ParanoidBaseTest
     assert ParanoidString.with_deleted.first.deleted?
   end
 
+  def test_delete_deleted?
+    ParanoidTime.first.delete
+    assert ParanoidTime.with_deleted.first.deleted?
+
+    ParanoidString.first.delete
+    assert ParanoidString.with_deleted.first.deleted?
+  end
+
+  def test_destroy_fully_deleted?
+    object = ParanoidTime.first
+    object.destroy_fully!
+    assert object.deleted?
+
+    object = ParanoidString.first
+    object.destroy_fully!
+    assert object.deleted?
+  end
+
+  def test_deleted_fully?
+    ParanoidTime.first.destroy
+    assert_not ParanoidTime.with_deleted.first.deleted_fully?
+
+    ParanoidString.first.destroy
+    assert ParanoidString.with_deleted.first.deleted?
+  end
+
+  def test_delete_deleted_fully?
+    ParanoidTime.first.delete
+    assert_not ParanoidTime.with_deleted.first.deleted_fully?
+  end
+
+  def test_destroy_fully_deleted_fully?
+    object = ParanoidTime.first
+    object.destroy_fully!
+    assert object.deleted_fully?
+  end
+
   def test_paranoid_destroy_callbacks
     @paranoid_with_callback = ParanoidWithCallback.first
     ParanoidWithCallback.transaction do


### PR DESCRIPTION
Part of #108, fixing the following issue:

> There is no way to know if a record was soft deleted or hard deleted in a destroy callback.

destroyed?/deleted? returns true iff an object is deleted (soft or hard).
destroyed_fully?/deleted_fully? returns true iff an object is deleted from the database (hard destroy).