### PR TITLE
Update set of supported rubies to 2.4-2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 2.7.0
   - ruby-head
   - jruby-9.2.8.0
 gemfile:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,10 @@ script: "bundle exec rake test"
 cache:
   - bundler
 rvm:
-  - 2.2.10
-  - 2.3.8
   - 2.4.9
   - 2.5.7
   - 2.6.5
   - ruby-head
-  - jruby-9.1.17.0
   - jruby-9.2.8.0
 gemfile:
   - gemfiles/active_record_52.gemfile
@@ -22,22 +19,10 @@ matrix:
     - gemfile: gemfiles/active_record_edge.gemfile
     - rvm: ruby-head
   exclude:
-    - rvm: 2.2.10
-      gemfile: gemfiles/active_record_edge.gemfile
-    - rvm: 2.3.8
-      gemfile: gemfiles/active_record_edge.gemfile
     - rvm: 2.4.9
       gemfile: gemfiles/active_record_edge.gemfile
-    - rvm: 2.2.10
-      gemfile: gemfiles/active_record_60.gemfile
-    - rvm: 2.3.8
-      gemfile: gemfiles/active_record_60.gemfile
     - rvm: 2.4.9
       gemfile: gemfiles/active_record_60.gemfile
-    - rvm: jruby-9.1.17.0
-      gemfile: gemfiles/active_record_60.gemfile
-    - rvm: jruby-9.1.17.0
-      gemfile: gemfiles/active_record_edge.gemfile
   fast_finish: true
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ recoverable later.
 
 ## Support
 
-**This branch targets Rails 5.2+ only**
+**This branch targets Rails 5.2+ and Ruby 2.4+ only**
 
-If you're working with Rails 5.1 and earlier, please switch to the corresponding branch or require an older version of the `acts_as_paranoid` gem.
+If you're working with Rails 5.1 and earlier, or with Ruby 2.3 or earlier,
+please switch to the corresponding branch or require an older version of the
+`acts_as_paranoid` gem.
 
 ### Known issues with Rails 5.2+
 
-* Using acts_as_paranoid and ActiveStorage on the same model
+* Using `acts_as_paranoid` and ActiveStorage on the same model
   [leads to a SystemStackError](https://github.com/ActsAsParanoid/acts_as_paranoid/issues/103).
 * You cannot directly create a model in a deleted state.
 


### PR DESCRIPTION
* Drop support for Ruby 2.3 and below, since they are unmaintained
* Add Ruby 2.7 to the build matrix