### PR TITLE
Add SimpleCov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 gemfiles/*.lock
 .idea/
 .ruby-version
+coverage/

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rdoc"
   spec.add_development_dependency "rubocop", "~> 0.79.0"
+  spec.add_development_dependency "simplecov", "~> 0.18.1"
 end

--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "active_record"
 require "acts_as_paranoid/core"
 require "acts_as_paranoid/associations"
 require "acts_as_paranoid/validations"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,11 +2,16 @@
 
 require "bundler"
 begin
-  Bundler.require(:default, :development)
+  Bundler.load
 rescue Bundler::BundlerError => e
   warn e.message
   warn "Run `bundle install` to install missing gems"
   exit e.status_code
+end
+
+require "simplecov"
+SimpleCov.start do
+  enable_coverage :branch
 end
 
 require "acts_as_paranoid"


### PR DESCRIPTION
- Add simplecov dependency
- Make sure acts_as_paranoid is loaded after SimpleCov.start by not loading everything through Bundler.require
- Activate branche coverage
- Ignore coverage output