### PR TITLE
Silence warnings

### DIFF
--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -199,8 +199,7 @@ class AssociationsTest < ParanoidBaseTest
 
   def test_includes_with_deleted
     paranoid_time = ParanoidTime.first
-    paranoid_has_many_dependant = paranoid_time.paranoid_has_many_dependants
-      .create(name: "dependant!")
+    paranoid_time.paranoid_has_many_dependants.create(name: "dependant!")
 
     paranoid_time.destroy
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -286,7 +286,13 @@ end
 
 class DoubleHasOneNotParanoid < HasOneNotParanoid
   belongs_to :paranoid_time, with_deleted: true
-  belongs_to :paranoid_time, with_deleted: true
+  begin
+    verbose = $VERBOSE
+    $VERBOSE = false
+    belongs_to :paranoid_time, with_deleted: true
+  ensure
+    $VERBOSE = verbose
+  end
 end
 
 class ParanoidWithCounterCache < ActiveRecord::Base


### PR DESCRIPTION
This silences warnings we can do something about. Ruby 2.6 running the tests should be warning-free. For 2.7, we have to wait for new Rails releases.