### PR TITLE
Improve dev experience

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@
 
 source "https://rubygems.org"
 
+gem "activerecord", require: "active_record"
+gem "activesupport", require: "active_support"
+
 # Development dependencies
 group :development do
   gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,10 @@ namespace :test do
   versions.each do |version|
     desc "Test acts_as_paranoid against #{version}"
     task version do
+      if ENV["RUBYOPT"] =~ %r{bundler/setup}
+        raise "Do not run the test:#{version} task with bundle exec!"
+      end
+
       sh "BUNDLE_GEMFILE='gemfiles/#{version}.gemfile' bundle install --quiet"
       sh "BUNDLE_GEMFILE='gemfiles/#{version}.gemfile' bundle exec rake -t test"
     end


### PR DESCRIPTION
* Guards against the common mistake of running the `test:active_record_*` tasks with `bundle exec`
* Makes running `bundle exec rake test` work