### PR TITLE
Simplify validation override

### DIFF
--- a/lib/acts_as_paranoid/validations.rb
+++ b/lib/acts_as_paranoid/validations.rb
@@ -9,28 +9,10 @@ module ActsAsParanoid
     end
 
     class UniquenessWithoutDeletedValidator < ActiveRecord::Validations::UniquenessValidator
-      def validate_each(record, attribute, value)
-        finder_class = find_finder_class_for(record)
-        table = finder_class.arel_table
+      private
 
-        relation = build_relation(finder_class, attribute, value)
-        if record.persisted?
-          [Array(finder_class.primary_key), Array(record.send(:id))]
-            .transpose
-            .each do |pk_key, pk_value|
-            relation = relation.where(table[pk_key.to_sym].not_eq(pk_value))
-          end
-        end
-
-        Array.wrap(options[:scope]).each do |scope_item|
-          relation = relation.where(table[scope_item].eq(record.public_send(scope_item)))
-        end
-
-        if relation.where(finder_class.paranoid_default_scope).exists?(relation)
-          record.errors.add(attribute,
-                            :taken,
-                            options.except(:case_sensitive, :scope).merge(value: value))
-        end
+      def build_relation(klass, attribute, value)
+        super.where(klass.paranoid_default_scope)
       end
     end
 


### PR DESCRIPTION
Instead of re-implementing all of `#validate_each`, just extend the `#build_relation` method by adding the paranoid scope.