### PR TITLE
Use correct unscope syntax so unscope works on Rails Edge

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -106,7 +106,7 @@ module ActsAsParanoid
       def without_paranoid_default_scope
         scope = all
 
-        scope = scope.unscope(where: paranoid_default_scope)
+        scope = scope.unscope(where: paranoid_column)
         # Fix problems with unscope group chain
         scope = scope.unscoped if scope.to_sql.include? paranoid_default_scope.to_sql
 


### PR DESCRIPTION
When using the hash form, unscope expects a symbol as the value. The previous version seems to have only worked accidentally.