### PR TITLE
Fix ruby 2.7 keyword argument deprecation warning

### DIFF
--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -39,7 +39,7 @@ module ActsAsParanoid
           end
         end
 
-        result = belongs_to_without_deleted(target, scope, options)
+        result = belongs_to_without_deleted(target, scope, **options)
 
         result.values.last.options[:with_deleted] = with_deleted if with_deleted
 


### PR DESCRIPTION
Fixes the ruby 2.7 deprecation warning emitted by acts_as_paranoid:

`lib/acts_as_paranoid/associations.rb:42: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`