### PR TITLE
Updates version number instructions for installing gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ please switch to the corresponding branch or require an older version of the
 #### Install gem:
 
 ```ruby
-gem 'acts_as_paranoid', '~> 0.7.0'
+gem 'acts_as_paranoid', '~> 0.6.3'
 ```
 
 ```shell


### PR DESCRIPTION
When I tried to  add `gem 'acts_as_paranoid', '~> 0.7.0'` to my `Gemfile`, it gave me: 

`Could not find gem 'acts_as_paranoid (~> 0.7.0)' in any of the gem sources listed in your Gemfile.`

After looking into it further, it looks like the latest version is only 0.6.3 in rubygems.org:

https://rubygems.org/gems/acts_as_paranoid