### PR TITLE
Update RuboCop/specify Ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   Exclude:
     - 'vendor/**/*'
   NewCops: enable
+  TargetRubyVersion: 2.4
 
 # Be lenient with line length
 Layout/LineLength:

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
   spec.homepage    = "https://github.com/ActsAsParanoid/acts_as_paranoid"
   spec.license     = "MIT"
 
+  spec.required_ruby_version = ">= 2.4.0"
+
   spec.files         = Dir["{lib}/**/*.rb", "LICENSE", "*.md"]
   spec.test_files    = Dir["test/*.rb"]
   spec.require_paths = ["lib"]

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rdoc"
-  spec.add_development_dependency "rubocop", "~> 0.88.0"
+  spec.add_development_dependency "rubocop", "~> 0.89.1"
   spec.add_development_dependency "simplecov", "~> 0.18.1"
 end


### PR DESCRIPTION
Updates RuboCop to 0.89.1, and fixes Gemspec/RequiredRubyVersion offense by making current lowest supported Ruby version (2.4) explicit.