### PR TITLE
Loosen dependency on simplecov

### DIFF
--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rdoc"
   spec.add_development_dependency "rubocop", "~> 0.89.1"
-  spec.add_development_dependency "simplecov", "~> 0.18.1"
+  spec.add_development_dependency "simplecov", [">= 0.18.1", "< 0.20.0"]
 end


### PR DESCRIPTION
Simplecov 0.19 is available; Update the development dependencies to allow its use. Also allow 0.18.1 for running the specs on Ruby 2.4, which is not supported by 0.19.