### PR TITLE
Fixed Inconsistency in `column_type`,` allow_nulls`, `recovery_value`

### DIFF
--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -32,8 +32,12 @@ module ActsAsParanoid
     }
     if options[:column_type] == "string"
       paranoid_configuration.merge!(deleted_value: "deleted")
+    elsif options[:column_type] == "boolean" && !options[:allow_nulls]
+      paranoid_configuration.merge!(recovery_value: false)
+    elsif options[:column_type] == "boolean"
+      paranoid_configuration.merge!(allow_nulls: true)
     end
-    paranoid_configuration.merge!(allow_nulls: true) if options[:column_type] == "boolean"
+
     paranoid_configuration.merge!(options) # user options
 
     unless %w[time boolean string].include? paranoid_configuration[:column_type]

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -533,6 +533,24 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal 0, ParanoidBooleanNotNullable.with_deleted.where(id: ps).count
   end
 
+  def test_boolean_type_with_no_nil_value_after_recover
+    ps = ParanoidBooleanNotNullable.create!
+    ps.destroy
+    assert_equal 1, ParanoidBooleanNotNullable.only_deleted.where(id: ps).count
+
+    ps.recover
+    assert_equal 1, ParanoidBooleanNotNullable.where(id: ps).count
+  end
+
+  def test_boolean_type_with_no_nil_value_after_recover!
+    ps = ParanoidBooleanNotNullable.create!
+    ps.destroy
+    assert_equal 1, ParanoidBooleanNotNullable.only_deleted.where(id: ps).count
+
+    ps.recover!
+    assert_equal 1, ParanoidBooleanNotNullable.where(id: ps).count
+  end
+
   def test_no_double_tap_destroys_fully
     ps = ParanoidNoDoubleTapDestroysFully.create!
     2.times { ps.destroy }


### PR DESCRIPTION
Thank you for providing such a great gem.
I created this PR because I ran into one problem while using this gem in my project.

## Expect
In case of `column type:" boolean "` and `allow nulls: false`, `nil` should not be stored in the `deleted` column.

## Actual
However, when the `recover` and` recover!` methods are used for the object of the class with the following conditions,` nil` is stored in the `deleted` column.

```
class ParanoidBooleanNotNullable < ActiveRecord::Base
  acts_as_paranoid column: "deleted", column_type: "boolean", allow_nulls: false
end

ParanoidBooleanNotNullable.create!
ParanoidBooleanNotNullable.first.destroy
ParanoidBooleanNotNullable.delete_flag # => true
ParanoidBooleanNotNullable.only_deleted.first.recover # => true
ParanoidBooleanNotNullable.delete_flag # => nil 'expected is false'
```

## Changes

Set default value `recovery_value` to` false` for case of`column_type:" boolean "` and `allow_nulls: false`.