### PR TITLE
Test and fix deletion time scopes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,11 @@ Layout/MultilineMethodCallIndentation:
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
+# Allow test classes to have any length
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*'
+
 # In guard clauses, if ! is often more immediately clear
 Style/NegatedIf:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,10 +10,6 @@
 Metrics/AbcSize:
   Max: 47
 
-# Configuration parameters: CountComments, CountAsOne.
-Metrics/ClassLength:
-  Max: 516
-
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:
   Max: 10

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -96,10 +96,12 @@ module ActsAsParanoid
         }
 
         scope :deleted_after_time, lambda { |time|
-          where("#{table_name}.#{paranoid_column} > ?", time)
+          only_deleted
+            .where("#{table_name}.#{paranoid_column} > ?", time)
         }
         scope :deleted_before_time, lambda { |time|
-          where("#{table_name}.#{paranoid_column} < ?", time)
+          only_deleted
+            .where("#{table_name}.#{paranoid_column} < ?", time)
         }
       end
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -676,4 +676,26 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal "explicit_table.deleted_at", ParanoidWithExplicitTableNameAfterMacro
       .paranoid_column_reference
   end
+
+  def test_deleted_after_time
+    ParanoidTime.first.destroy
+    assert_equal 0, ParanoidTime.deleted_after_time(1.hour.from_now).count
+    assert_equal 1, ParanoidTime.deleted_after_time(1.hour.ago).count
+  end
+
+  def test_deleted_before_time
+    ParanoidTime.first.destroy
+    assert_equal 1, ParanoidTime.deleted_before_time(1.hour.from_now).count
+    assert_equal 0, ParanoidTime.deleted_before_time(1.hour.ago).count
+  end
+
+  def test_deleted_inside_time_window
+    ParanoidTime.first.destroy
+    assert_equal 1, ParanoidTime.deleted_inside_time_window(1.minute.ago, 2.minutes).count
+    assert_equal 1,
+                 ParanoidTime.deleted_inside_time_window(1.minute.from_now, 2.minutes).count
+    assert_equal 0, ParanoidTime.deleted_inside_time_window(3.minutes.ago, 1.minute).count
+    assert_equal 0,
+                 ParanoidTime.deleted_inside_time_window(3.minutes.from_now, 1.minute).count
+  end
 end


### PR DESCRIPTION
The scopes `deleted_after_time` and `deleted_before_time` lacked code to remove the default scope to non-deleted items.

Fixes #42.