### PR TITLE
Test uniqueness validation without deleted with serialized attributes

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -241,6 +241,14 @@ def setup_db
 
       timestamps t
     end
+
+    create_table :paranoid_with_serialized_columns do |t|
+      t.string :name
+      t.datetime :deleted_at
+      t.string :colors
+
+      timestamps t
+    end
   end
 end
 # rubocop:enable Metrics/AbcSize
@@ -563,4 +571,13 @@ end
 class ParanoidWithExplicitTableNameAfterMacro < ActiveRecord::Base
   acts_as_paranoid
   self.table_name = "explicit_table"
+end
+
+class ParanoidWithSerializedColumn < ActiveRecord::Base
+  acts_as_paranoid
+  validates_as_paranoid
+
+  serialize :colors, Array
+
+  validates_uniqueness_of_without_deleted :colors
 end

--- a/test/test_validations.rb
+++ b/test/test_validations.rb
@@ -23,6 +23,24 @@ class ValidatesUniquenessTest < ParanoidBaseTest
     end
   end
 
+  def test_validate_serialized_attribute_without_deleted
+    ParanoidWithSerializedColumn.create!(name: "ParanoidWithSerializedColumn #1",
+                                         colors: %w[Cyan Maroon])
+    record = ParanoidWithSerializedColumn.new(name: "ParanoidWithSerializedColumn #2")
+    record.colors = %w[Cyan Maroon]
+    refute record.valid?
+
+    record.colors = %w[Beige Turquoise]
+    assert record.valid?
+  end
+
+  def test_updated_serialized_attribute_validated_without_deleted
+    record = ParanoidWithSerializedColumn.create!(name: "ParanoidWithSerializedColumn #1",
+                                                  colors: %w[Cyan Maroon])
+    record.update!(colors: %w[Beige Turquoise])
+    assert record.valid?
+  end
+
   def test_models_with_scoped_validations_can_be_multiply_deleted
     model_a = ParanoidWithScopedValidation.create(name: "Model A", category: "Category A")
     model_b = ParanoidWithScopedValidation.create(name: "Model B", category: "Category B")


### PR DESCRIPTION
Closes #43. This issue was probably fixed by #85. The present pull request adds tests to demonstrate that validation behaves correctly with serialized attributes.