### PR TITLE
Avoid querying nil belongs_to associations when recovering

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,7 @@ Metrics/MethodLength:
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 151
+  Max: 155
 
 # Configuration parameters: IgnoredMethods.
 Metrics/PerceivedComplexity:

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -212,6 +212,10 @@ module ActsAsParanoid
         assoc = association(reflection.name)
         next unless (klass = assoc.klass).paranoid?
 
+        if reflection.belongs_to? && attributes[reflection.association_foreign_key].nil?
+          next
+        end
+
         scope = klass.only_deleted.merge(get_association_scope(assoc))
 
         # We can only recover by window if both parent and dependant have a


### PR DESCRIPTION
For a `belongs_to` association where the foreign key is nil, the existing code would create a scope on the assoicated table with a where clause selecting `id IS NULL`. This would always fail to find any records, but it's better to not perform the query at all.