### PR TITLE
Calculate recovery_value instead of using a setting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,10 @@ Metrics/MethodLength:
   Exclude:
     - 'test/**/*'
 
+# Allow else clauses with explicit nil value
+Style/EmptyElse:
+  EnforcedStyle: empty
+
 # In guard clauses, if ! is often more immediately clear
 Style/NegatedIf:
   Enabled: false

--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -27,15 +27,10 @@ module ActsAsParanoid
       column_type: "time",
       recover_dependent_associations: true,
       dependent_recovery_window: 2.minutes,
-      recovery_value: nil,
       double_tap_destroys_fully: true
     }
     if options[:column_type] == "string"
       paranoid_configuration.merge!(deleted_value: "deleted")
-    elsif options[:column_type] == "boolean" && !options[:allow_nulls]
-      paranoid_configuration.merge!(recovery_value: false)
-    elsif options[:column_type] == "boolean"
-      paranoid_configuration.merge!(allow_nulls: true)
     end
 
     paranoid_configuration.merge!(options) # user options

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -89,7 +89,12 @@ module ActsAsParanoid
       end
 
       def recovery_value
-        if boolean_type_not_nullable?
+        if paranoid_configuration.key? :recovery_value
+          ActiveSupport::Deprecation.warn \
+            "The recovery_value setting is deprecated and will be removed in" \
+            " ActsAsParanoid 0.8.0"
+          paranoid_configuration[:recovery_value]
+        elsif boolean_type_not_nullable?
           false
         else
           nil

--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -88,6 +88,14 @@ module ActsAsParanoid
         end
       end
 
+      def recovery_value
+        if boolean_type_not_nullable?
+          false
+        else
+          nil
+        end
+      end
+
       protected
 
       def define_deleted_time_scopes
@@ -189,7 +197,7 @@ module ActsAsParanoid
         run_callbacks :recover do
           increment_counters_on_associations
           deleted_value = paranoid_value
-          self.paranoid_value = self.class.paranoid_configuration[:recovery_value]
+          self.paranoid_value = self.class.recovery_value
           result = if options[:raise_error]
                      save!
                    else

--- a/test/test_deprecated_behavior.rb
+++ b/test/test_deprecated_behavior.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class DeprecatedBehaviorTest < ActiveSupport::TestCase
+  class StringlyParanoid < ActiveRecord::Base
+    acts_as_paranoid column_type: "string", column: "foo", recovery_value: "alive"
+  end
+
+  def setup
+    ActiveRecord::Schema.define(version: 1) do
+      create_table :stringly_paranoids do |t|
+        t.string :foo
+
+        timestamps t
+      end
+    end
+  end
+
+  def teardown
+    teardown_db
+  end
+
+  def test_recovery_value
+    record = StringlyParanoid.create!
+    record.destroy
+    record.recover
+    assert_equal "alive", record.paranoid_value
+  end
+end


### PR DESCRIPTION
The `recovery_value` setting was introduced in #60 for use with non-null booleans, but since there's only one sensible option for that case there is no point in making it a setting.

Final removal of this setting as a breaking change in a way, although this setting was never documented. Therefore, using this setting will still work for now and give a deprecation warning.

Closes #72.