### PR TITLE
Replace `destroy!` with `destroy_fully!` on relations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,13 +10,18 @@
 Metrics/AbcSize:
   Max: 47
 
+# Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
+# IgnoredMethods: refine
+Metrics/BlockLength:
+  Max: 29
+
 # Configuration parameters: IgnoredMethods.
 Metrics/CyclomaticComplexity:
   Max: 10
 
 # Configuration parameters: CountComments, CountAsOne, ExcludedMethods, IgnoredMethods.
 Metrics/MethodLength:
-  Max: 28
+  Max: 31
 
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:

--- a/lib/acts_as_paranoid/relation.rb
+++ b/lib/acts_as_paranoid/relation.rb
@@ -29,7 +29,7 @@ module ActsAsParanoid
           end
         end
 
-        def destroy!(id_or_array)
+        def destroy_fully!(id_or_array)
           where(primary_key => id_or_array).orig_delete_all
         end
       end

--- a/lib/acts_as_paranoid/relation.rb
+++ b/lib/acts_as_paranoid/relation.rb
@@ -29,6 +29,13 @@ module ActsAsParanoid
           end
         end
 
+        def destroy!(id_or_array)
+          destroy_fully! id_or_array
+        end
+
+        deprecate :destroy!,
+                  deprecator: ActiveSupport::Deprecation.new("0.8.0", "ActsAsParanoid")
+
         def destroy_fully!(id_or_array)
           where(primary_key => id_or_array).orig_delete_all
         end

--- a/test/test_relations.rb
+++ b/test/test_relations.rb
@@ -156,9 +156,8 @@ class RelationsTest < ActiveSupport::TestCase
     assert_equal 2, not_paranoid.paranoid_chocolates.with_deleted.count
   end
 
-  def test_real_removal_through_relation_with_destroy_bang
-    # Relation.destroy!: aliased to delete
-    ParanoidForest.rainforest.destroy!(@paranoid_forest_3)
+  def test_real_removal_through_relation_with_destroy_fully
+    ParanoidForest.rainforest.destroy_fully!(@paranoid_forest_3)
     assert_equal 1, ParanoidForest.rainforest.count
     assert_equal 1, ParanoidForest.rainforest.with_deleted.count
     assert_equal 0, ParanoidForest.rainforest.only_deleted.count

--- a/test/test_relations.rb
+++ b/test/test_relations.rb
@@ -163,6 +163,13 @@ class RelationsTest < ActiveSupport::TestCase
     assert_equal 0, ParanoidForest.rainforest.only_deleted.count
   end
 
+  def test_real_removal_through_relation_with_deprecated_destroy!
+    ParanoidForest.rainforest.destroy!(@paranoid_forest_3)
+    assert_equal 1, ParanoidForest.rainforest.count
+    assert_equal 1, ParanoidForest.rainforest.with_deleted.count
+    assert_equal 0, ParanoidForest.rainforest.only_deleted.count
+  end
+
   def test_two_step_real_removal_through_relation_with_destroy
     # destroy: two-step through a relation
     paranoid_tree = @paranoid_forest_1.paranoid_trees.first


### PR DESCRIPTION
On single records, `destroy!` was already replaced with `destroy_fully!` before. This change does the same for relations. This reduces surprising behavior when compared to standard ActiveRecord.

`destroy!` is kept for now with a deprecation message.

See #82.