### PR TITLE
Start test setup simplification

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,11 @@ Metrics/ClassLength:
   Exclude:
     - 'test/**/*'
 
+# Allow test methods to have any length
+Metrics/MethodLength:
+  Exclude:
+    - 'test/**/*'
+
 # In guard clauses, if ! is often more immediately clear
 Style/NegatedIf:
   Enabled: false

--- a/test/test_default_scopes.rb
+++ b/test/test_default_scopes.rb
@@ -2,9 +2,16 @@
 
 require "test_helper"
 
-class MultipleDefaultScopesTest < ParanoidBaseTest
+class MultipleDefaultScopesTest < ActiveSupport::TestCase
   def setup
-    setup_db
+    ActiveRecord::Schema.define(version: 1) do
+      create_table :paranoid_polygons do |t|
+        t.integer :sides
+        t.datetime :deleted_at
+
+        timestamps t
+      end
+    end
 
     ParanoidPolygon.create! sides: 3
     ParanoidPolygon.create! sides: 3
@@ -13,6 +20,10 @@ class MultipleDefaultScopesTest < ParanoidBaseTest
 
     assert_equal 3, ParanoidPolygon.count
     assert_equal 4, ParanoidPolygon.unscoped.count
+  end
+
+  def teardown
+    teardown_db
   end
 
   def test_fake_removal_with_multiple_default_scope

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,7 +38,6 @@ file_path = File.join(log_dir, "test.log")
 ActiveRecord::Base.logger = Logger.new(file_path)
 
 # rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/MethodLength
 def setup_db
   ActiveRecord::Schema.define(version: 1) do # rubocop:disable Metrics/BlockLength
     create_table :paranoid_times do |t|
@@ -240,9 +239,8 @@ def setup_db
     end
   end
 end
-# rubocop:enable Metrics/AbcSize
-# rubocop:enable Metrics/MethodLength
 
+# rubocop:enable Metrics/AbcSize
 def timestamps(table)
   table.column  :created_at, :timestamp, null: false
   table.column  :updated_at, :timestamp, null: false

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -174,22 +174,6 @@ def setup_db
       timestamps t
     end
 
-    create_table :paranoid_forests do |t|
-      t.string   :name
-      t.boolean  :rainforest
-      t.datetime :deleted_at
-
-      timestamps t
-    end
-
-    create_table :paranoid_trees do |t|
-      t.integer  :paranoid_forest_id
-      t.string   :name
-      t.datetime :deleted_at
-
-      timestamps t
-    end
-
     create_table :paranoid_polygons do |t|
       t.integer :sides
       t.datetime :deleted_at
@@ -536,20 +520,6 @@ class ParanoidBaseTest < ActiveSupport::TestCase
     # puts sql here if you want to debug
     model.class.connection.select_one(sql)
   end
-end
-
-class ParanoidForest < ActiveRecord::Base
-  acts_as_paranoid
-
-  scope :rainforest, -> { where(rainforest: true) }
-
-  has_many :paranoid_trees, dependent: :destroy
-end
-
-class ParanoidTree < ActiveRecord::Base
-  acts_as_paranoid
-  belongs_to :paranoid_forest
-  validates_presence_of :name
 end
 
 class ParanoidPolygon < ActiveRecord::Base

--- a/test/test_relations.rb
+++ b/test/test_relations.rb
@@ -2,9 +2,63 @@
 
 require "test_helper"
 
-class RelationsTest < ParanoidBaseTest
+class RelationsTest < ActiveSupport::TestCase
+  class ParanoidForest < ActiveRecord::Base
+    acts_as_paranoid
+
+    scope :rainforest, -> { where(rainforest: true) }
+
+    has_many :paranoid_trees, dependent: :destroy
+  end
+
+  class ParanoidTree < ActiveRecord::Base
+    acts_as_paranoid
+    belongs_to :paranoid_forest
+    validates_presence_of :name
+  end
+
+  class NotParanoidBowl < ActiveRecord::Base
+    has_many :paranoid_chocolates, dependent: :destroy
+  end
+
+  class ParanoidChocolate < ActiveRecord::Base
+    acts_as_paranoid
+    belongs_to :not_paranoid_bowl
+    validates_presence_of :name
+  end
+
   def setup
-    setup_db
+    ActiveRecord::Schema.define(version: 1) do
+      create_table :paranoid_forests do |t|
+        t.string   :name
+        t.boolean  :rainforest
+        t.datetime :deleted_at
+
+        timestamps t
+      end
+
+      create_table :paranoid_trees do |t|
+        t.integer  :paranoid_forest_id
+        t.string   :name
+        t.datetime :deleted_at
+
+        timestamps t
+      end
+
+      create_table :not_paranoid_bowls do |t|
+        t.string   :name
+
+        timestamps t
+      end
+
+      create_table :paranoid_chocolates do |t|
+        t.integer  :not_paranoid_bowl_id
+        t.string   :name
+        t.datetime :deleted_at
+
+        timestamps t
+      end
+    end
 
     @paranoid_forest_1 = ParanoidForest.create! name: "ParanoidForest #1"
     @paranoid_forest_2 = ParanoidForest.create! name: "ParanoidForest #2", rainforest: true
@@ -19,6 +73,10 @@ class RelationsTest < ParanoidBaseTest
     @paranoid_forest_2.paranoid_trees.create! name: "ParanoidTree #4"
 
     assert_equal 4, ParanoidTree.count
+  end
+
+  def teardown
+    teardown_db
   end
 
   def test_filtering_with_scopes
@@ -89,13 +147,13 @@ class RelationsTest < ParanoidBaseTest
   end
 
   def test_fake_removal_through_has_many_relation_of_non_paranoid_model
-    not_paranoid = NotParanoid.create! name: "NotParanoid #1"
-    not_paranoid.paranoid_times.create! name: "ParanoidTime #1"
-    not_paranoid.paranoid_times.create! name: "ParanoidTime #2"
+    not_paranoid = NotParanoidBowl.create! name: "NotParanoid #1"
+    not_paranoid.paranoid_chocolates.create! name: "ParanoidChocolate #1"
+    not_paranoid.paranoid_chocolates.create! name: "ParanoidChocolate #2"
 
-    not_paranoid.paranoid_times.destroy_all
-    assert_equal 0, not_paranoid.paranoid_times.count
-    assert_equal 2, not_paranoid.paranoid_times.with_deleted.count
+    not_paranoid.paranoid_chocolates.destroy_all
+    assert_equal 0, not_paranoid.paranoid_chocolates.count
+    assert_equal 2, not_paranoid.paranoid_chocolates.with_deleted.count
   end
 
   def test_real_removal_through_relation_with_destroy_bang


### PR DESCRIPTION
The existing test setup created tables for all models used during the tests. This is excessive. This pull requests starts the process of splitting up the database setup code so fewer tables are created and model definitions are more localized.