### PR TITLE
Update test of mass assignment to paranoid column

### DIFF
--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -346,13 +346,9 @@ class AssociationsTest < ParanoidBaseTest
     assert_not_nil not_paranoid.paranoid_time
   end
 
-  def test_mass_assignment_of_paranoid_column_enabled
-    if Gem.loaded_specs["activerecord"].version >= Gem::Version.new("5.2.0")
-      skip "Creation as deleted is not supported with Rails >= 5.2"
+  def test_mass_assignment_of_paranoid_column_disabled
+    assert_raises ActiveRecord::RecordNotSaved do
+      ParanoidTime.create! name: "Foo", deleted_at: Time.now
     end
-    now = Time.now
-    record = ParanoidTime.create! name: "Foo", deleted_at: now
-    assert_equal "Foo", record.name
-    assert_equal now, record.deleted_at
   end
 end


### PR DESCRIPTION
Assigning to the paranoid column is no longer supported: Rails does not support creating a model in a deleted state.