### PR TITLE
Add default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ option which is `true` by default. When set to `false`, entities that have
 have `true` will be considered deleted. When `true` everything that has a
 not-null value will be considered deleted.
 
+### Configure Default Options
+
+If you want to use a configuration option globally in your application
+as a default, you can set up the following in your application.rb or in
+an initializer:
+```ruby
+  # config/initializers/acts_as_paranoid.rb:
+  Rails.application.config.acts_as_paranoid_default_options = {
+    column: 'deleted',
+    recover_dependent_associations: false,
+    double_tap_destroys_fully: false,
+  }
+```
+This overrides the defaults set by the gem but in turn can still be overriden
+when defining a class as `acts_as_paranoid`.
+
 ### Filtering
 
 If a record is deleted by ActsAsParanoid, it won't be retrieved when accessing
@@ -246,7 +262,7 @@ p1.recover #=> fails validation!
 
 ### Status
 
-A paranoid object could be deleted or destroyed fully. 
+A paranoid object could be deleted or destroyed fully.
 
 You can check if the object is deleted with the `deleted?` helper
 

--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -29,6 +29,11 @@ module ActsAsParanoid
       dependent_recovery_window: 2.minutes,
       double_tap_destroys_fully: true
     }
+    if defined?(Rails)
+      paranoid_configuration.merge!(
+        Hash(::Rails.try(:application).try(:config).try(:acts_as_paranoid_default_options))
+      )
+    end
     if options[:column_type] == "string"
       paranoid_configuration.merge!(deleted_value: "deleted")
     end

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -733,4 +733,24 @@ class ParanoidTest < ParanoidBaseTest
     assert_equal 0,
                  ParanoidTime.deleted_inside_time_window(3.minutes.from_now, 1.minute).count
   end
+
+  def test_configure_default_configuration
+    Rails.application.config.acts_as_paranoid_default_options = {
+      column: "test_column_name",
+      double_tap_destroys_fully: false,
+    }
+
+    temporary_paranoiac = Class.new(ActiveRecord::Base) do
+      acts_as_paranoid
+    end
+
+    expected_default_options = {
+      column_type: "time",
+      column: "test_column_name",
+      dependent_recovery_window: 2.minutes,
+      double_tap_destroys_fully: false,
+      recover_dependent_associations: true,
+    }
+    assert_equal expected_default_options, temporary_paranoiac.paranoid_configuration
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,6 +37,14 @@ FileUtils.mkdir_p log_dir
 file_path = File.join(log_dir, "test.log")
 ActiveRecord::Base.logger = Logger.new(file_path)
 
+unless defined?(Rails) # simulate Rails config behaviour during tests
+  Rails = Struct.new(:application).new(
+    Struct.new(:config).new( # application attribute
+      OpenStruct.new # config attribute
+    )
+  )
+end
+
 # rubocop:disable Metrics/AbcSize
 def setup_db
   ActiveRecord::Schema.define(version: 1) do # rubocop:disable Metrics/BlockLength


### PR DESCRIPTION
closes #234

I think the implementation is rather straight forward, I am a bit concerned about testing this feature though. I came up with something that verifies the functionality of the feature but I needed to wiggle some things to make it work.

Since I usually use RSpec I am uncertain how to mock away the rails config with minitest. Also the necessity to do so maybe is a pointer that configuration of acts_as_paranoid should be handled differently? Please let me know what you think about it @mvz 🙂 