### PR TITLE
Introduce rubocop-minitest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_from: .rubocop_todo.yml
 
+require:
+  - rubocop-minitest
+
 # Exclude any vendored gems
 AllCops:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -29,7 +29,20 @@ Metrics/ModuleLength:
 
 # Configuration parameters: IgnoredMethods.
 Metrics/PerceivedComplexity:
-  Max: 11
+  Max: 10
+
+Minitest/AssertionInLifecycleHook:
+  Exclude:
+    - 'test/test_default_scopes.rb'
+    - 'test/test_relations.rb'
+
+Minitest/MultipleAssertions:
+  Max: 16
+
+# Cop supports --auto-correct.
+Minitest/TestMethodName:
+  Exclude:
+    - 'test/test_core.rb'
 
 # Configuration parameters: EnforcedStyle, CheckMethodNames, CheckSymbols, AllowedIdentifiers.
 # SupportedStyles: snake_case, normalcase, non_integer

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rdoc"
   spec.add_development_dependency "rubocop", "~> 1.12.0"
+  spec.add_development_dependency "rubocop-minitest", "~> 0.12.0"
   spec.add_development_dependency "simplecov", [">= 0.18.1", "< 0.22.0"]
 end

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rdoc"
   spec.add_development_dependency "rubocop", "~> 1.12.0"
-  spec.add_development_dependency "rubocop-minitest", "~> 0.12.0"
+  spec.add_development_dependency "rubocop-minitest", "~> 0.11.0"
   spec.add_development_dependency "simplecov", [">= 0.18.1", "< 0.22.0"]
 end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -179,7 +179,7 @@ class AssociationsTest < ParanoidBaseTest
 
     parent.reload
 
-    assert_equal [], parent.paranoid_has_many_dependants.to_a
+    assert_empty parent.paranoid_has_many_dependants.to_a
     assert_equal [child], parent.paranoid_has_many_dependants.with_deleted.to_a
   end
 
@@ -236,8 +236,8 @@ class AssociationsTest < ParanoidBaseTest
 
     left.reload
 
-    assert_equal [], left.paranoid_many_many_children, "Linking objects not deleted"
-    assert_equal [], left.paranoid_many_many_parent_rights,
+    assert_empty left.paranoid_many_many_children, "Linking objects not deleted"
+    assert_empty left.paranoid_many_many_parent_rights,
                  "Associated objects not unlinked"
     assert_equal right, ParanoidManyManyParentRight.find(right.id),
                  "Associated object deleted"
@@ -252,8 +252,8 @@ class AssociationsTest < ParanoidBaseTest
 
     left.reload
 
-    assert_equal [], left.paranoid_many_many_children, "Linking objects not deleted"
-    assert_equal [], left.paranoid_many_many_parent_rights,
+    assert_empty left.paranoid_many_many_children, "Linking objects not deleted"
+    assert_empty left.paranoid_many_many_parent_rights,
                  "Associated objects not unlinked"
     assert_equal right, ParanoidManyManyParentRight.find(right.id),
                  "Associated object deleted"
@@ -270,7 +270,7 @@ class AssociationsTest < ParanoidBaseTest
 
     left.reload
 
-    assert_equal [], left.paranoid_many_many_parent_rights, "Associated objects not deleted"
+    assert_empty left.paranoid_many_many_parent_rights, "Associated objects not deleted"
   end
 
   def test_cannot_find_a_paranoid_deleted_model

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -17,9 +17,9 @@ class ParanoidTest < ParanoidBaseTest
     assert_respond_to ParanoidTime, :deleted_before_time
     assert_respond_to ParanoidTime, :deleted_after_time
 
-    refute ParanoidBoolean.respond_to?(:deleted_inside_time_window)
-    refute ParanoidBoolean.respond_to?(:deleted_before_time)
-    refute ParanoidBoolean.respond_to?(:deleted_after_time)
+    refute_respond_to ParanoidBoolean, :deleted_inside_time_window
+    refute_respond_to ParanoidBoolean, :deleted_before_time
+    refute_respond_to ParanoidBoolean, :deleted_after_time
   end
 
   def test_fake_removal

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -13,9 +13,9 @@ class ParanoidTest < ParanoidBaseTest
   end
 
   def test_scope_inclusion_with_time_column_type
-    assert ParanoidTime.respond_to?(:deleted_inside_time_window)
-    assert ParanoidTime.respond_to?(:deleted_before_time)
-    assert ParanoidTime.respond_to?(:deleted_after_time)
+    assert_respond_to ParanoidTime, :deleted_inside_time_window
+    assert_respond_to ParanoidTime, :deleted_before_time
+    assert_respond_to ParanoidTime, :deleted_after_time
 
     refute ParanoidBoolean.respond_to?(:deleted_inside_time_window)
     refute ParanoidBoolean.respond_to?(:deleted_before_time)

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class ParanoidTest < ParanoidBaseTest
   def test_paranoid?
-    assert !NotParanoid.paranoid?
+    refute NotParanoid.paranoid?
     assert_raise(NoMethodError) { NotParanoid.delete_all! }
     assert_raise(NoMethodError) { NotParanoid.with_deleted }
     assert_raise(NoMethodError) { NotParanoid.only_deleted }
@@ -17,9 +17,9 @@ class ParanoidTest < ParanoidBaseTest
     assert ParanoidTime.respond_to?(:deleted_before_time)
     assert ParanoidTime.respond_to?(:deleted_after_time)
 
-    assert !ParanoidBoolean.respond_to?(:deleted_inside_time_window)
-    assert !ParanoidBoolean.respond_to?(:deleted_before_time)
-    assert !ParanoidBoolean.respond_to?(:deleted_after_time)
+    refute ParanoidBoolean.respond_to?(:deleted_inside_time_window)
+    refute ParanoidBoolean.respond_to?(:deleted_before_time)
+    refute ParanoidBoolean.respond_to?(:deleted_after_time)
   end
 
   def test_fake_removal

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -498,10 +498,6 @@ class ParanoidBaseTest < ActiveSupport::TestCase
     teardown_db
   end
 
-  def assert_empty(collection)
-    assert(collection.respond_to?(:empty?) && collection.empty?)
-  end
-
   def assert_paranoid_deletion(model)
     row = find_row(model)
     assert_not_nil row, "#{model.class} entirely deleted"

--- a/test/test_validations.rb
+++ b/test/test_validations.rb
@@ -5,9 +5,9 @@ require "test_helper"
 class ValidatesUniquenessTest < ParanoidBaseTest
   def test_should_include_deleted_by_default
     ParanoidTime.new(name: "paranoid").tap do |record|
-      assert !record.valid?
+      refute record.valid?
       ParanoidTime.first.destroy
-      assert !record.valid?
+      refute record.valid?
       ParanoidTime.only_deleted.first.destroy!
       assert record.valid?
     end


### PR DESCRIPTION
- Add rubocop-minitest, using version 0.11.x so Ruby 2.4 is supported
- Autocorrect several offenses
- Remove home-grown assert_empty implementation
- Regenerate RuboCop to-do file to silence warnings that need more work