### PR TITLE
No need to stale paranoid_value when destroying fully

### DIFF
--- a/lib/acts_as_paranoid/core.rb
+++ b/lib/acts_as_paranoid/core.rb
@@ -157,7 +157,6 @@ module ActsAsParanoid
             decrement_counters_on_associations
           end
 
-          stale_paranoid_value
           @destroyed = true
           freeze
         end

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -85,6 +85,13 @@ class ParanoidTest < ParanoidBaseTest
     assert_not_nil pt.paranoid_value
   end
 
+  def test_non_persisted_destroy_fully!
+    pt = ParanoidTime.new
+    assert_nil pt.paranoid_value
+    pt.destroy_fully!
+    assert_nil pt.paranoid_value
+  end
+
   def test_removal_not_persisted
     assert ParanoidTime.new.destroy
   end


### PR DESCRIPTION
Part of #108.
