### PR TITLE
Drop support for Ruby 2.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,10 +18,6 @@ jobs:
       matrix:
         ruby: [2.5, 2.6, 2.7, "3.0", jruby-9.2]
         gemfile: [active_record_52, active_record_60, active_record_61]
-        include:
-          # Only Rails 5.2 supports Ruby 2.4
-          - ruby: 2.4
-            gemfile: active_record_52
         exclude:
           # Rails 5.2 does not support Ruby 3.0
           - ruby: "3.0"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   Exclude:
     - 'vendor/**/*'
   NewCops: enable
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 # Be lenient with line length
 Layout/LineLength:

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ recoverable later.
 
 ## Support
 
-**This branch targets Rails 5.2+ and Ruby 2.4+ only**
+**This branch targets Rails 5.2+ and Ruby 2.5+ only**
 
-If you're working with Rails 5.1 and earlier, or with Ruby 2.3 or earlier,
+If you're working with Rails 5.1 and earlier, or with Ruby 2.4 or earlier,
 please switch to the corresponding branch or require an older version of the
 `acts_as_paranoid` gem.
 
@@ -27,7 +27,7 @@ please switch to the corresponding branch or require an older version of the
 #### Install gem:
 
 ```ruby
-gem 'acts_as_paranoid', '~> 0.7.0'
+gem 'acts_as_paranoid'
 ```
 
 ```shell

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.homepage    = "https://github.com/ActsAsParanoid/acts_as_paranoid"
   spec.license     = "MIT"
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.files         = Dir["{lib}/**/*.rb", "LICENSE", "*.md"]
   spec.test_files    = Dir["test/*.rb"]


### PR DESCRIPTION
Ruby 2.4 has been EOL for quite some time.
