### PR TITLE
update to support rails 7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,6 +25,7 @@ jobs:
           # Rails 5.2 does not support Ruby 3.0
           - ruby: "3.0"
             gemfile: active_record_52
+          # Rails 7.0 does not support Ruby 2.6
           - ruby: 2.6
             gemfile: active_record_70
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         ruby: [2.6, 2.7, "3.0", jruby-9.3]
-        gemfile: [active_record_52, active_record_60, active_record_61]
+        gemfile: [active_record_52, active_record_60, active_record_61, active_record_70]
         exclude:
           # Rails 5.2 does not support Ruby 3.0
           - ruby: "3.0"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,6 +25,8 @@ jobs:
           # Rails 5.2 does not support Ruby 3.0
           - ruby: "3.0"
             gemfile: active_record_52
+          - ruby: 2.6
+            gemfile: active_record_70
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,8 +25,10 @@ jobs:
           # Rails 5.2 does not support Ruby 3.0
           - ruby: "3.0"
             gemfile: active_record_52
-          # Rails 7.0 does not support Ruby 2.6
+          # Rails 7.0 does not support Ruby 2.6 and jruby-9.3 is still depends on ruby 2.6
           - ruby: 2.6
+            gemfile: active_record_70
+          - ruby: jruby-9.3
             gemfile: active_record_70
 
     env:

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.files = File.read("Manifest.txt").split
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", ">= 5.2", "<= 7.1"
-  spec.add_runtime_dependency "activesupport", ">= 5.2", "<= 7.1"
+  spec.add_runtime_dependency "activerecord", ">= 5.2", "< 7.1"
+  spec.add_runtime_dependency "activesupport", ">= 5.2", "< 7.1"
 
   spec.add_development_dependency "minitest", "~> 5.14"
   spec.add_development_dependency "minitest-focus", "~> 1.3.0"

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.files = File.read("Manifest.txt").split
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", ">= 5.2", "< 7.0"
-  spec.add_runtime_dependency "activesupport", ">= 5.2", "< 7.0"
+  spec.add_runtime_dependency "activerecord", ">= 5.2", "<= 7.0"
+  spec.add_runtime_dependency "activesupport", ">= 5.2", "<= 7.0"
 
   spec.add_development_dependency "minitest", "~> 5.14"
   spec.add_development_dependency "minitest-focus", "~> 1.3.0"

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
   spec.files = File.read("Manifest.txt").split
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", ">= 5.2", "<= 7.0"
-  spec.add_runtime_dependency "activesupport", ">= 5.2", "<= 7.0"
+  spec.add_runtime_dependency "activerecord", ">= 5.2", "<= 7.1"
+  spec.add_runtime_dependency "activesupport", ">= 5.2", "<= 7.1"
 
   spec.add_development_dependency "minitest", "~> 5.14"
   spec.add_development_dependency "minitest-focus", "~> 1.3.0"

--- a/gemfiles/active_record_70.gemfile
+++ b/gemfiles/active_record_70.gemfile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "activerecord", "~> 7.0.0", require: "active_record"
+gem "activesupport", "~> 7.0.0", require: "active_support"
+
+# Development dependencies
+group :development do
+  gem "activerecord-jdbcsqlite3-adapter", "~> 61.0", platforms: [:jruby]
+  gem "sqlite3", platforms: [:ruby]
+end
+
+gemspec path: "../"

--- a/gemfiles/active_record_70.gemfile
+++ b/gemfiles/active_record_70.gemfile
@@ -7,7 +7,7 @@ gem "activesupport", "~> 7.0.0", require: "active_support"
 
 # Development dependencies
 group :development do
-  gem "activerecord-jdbcsqlite3-adapter", "~> 61.0", platforms: [:jruby]
+  gem "activerecord-jdbcsqlite3-adapter", "~> 61.1", platforms: [:jruby]
   gem "sqlite3", platforms: [:ruby]
 end
 


### PR DESCRIPTION
Rails 7.0.0 is already launch, I update the gemspec and active record dependencies in gemfiles. Hope it helps, 

tested in my local environment

gemfile: 
`gem 'acts_as_paranoid',               '~> 0.7.3', git: 'https://github.com/cloudsbird/acts_as_paranoid', branch: 'rails_7_support'`

ruby: 3.0.0
rails: 7.0.0
