### PR TITLE
Fix association building for belongs_to with :with_deleted option

### DIFF
--- a/lib/acts_as_paranoid.rb
+++ b/lib/acts_as_paranoid.rb
@@ -5,6 +5,7 @@ require "acts_as_paranoid/core"
 require "acts_as_paranoid/associations"
 require "acts_as_paranoid/validations"
 require "acts_as_paranoid/relation"
+require "acts_as_paranoid/association_reflection"
 
 module ActsAsParanoid
   def paranoid?
@@ -63,3 +64,6 @@ ActiveRecord::Relation.include ActsAsParanoid::Relation
 
 # Push the recover callback onto the activerecord callback list
 ActiveRecord::Callbacks::CALLBACKS.push(:before_recover, :after_recover)
+
+ActiveRecord::Reflection::AssociationReflection
+  .prepend ActsAsParanoid::AssociationReflection

--- a/lib/acts_as_paranoid/association_reflection.rb
+++ b/lib/acts_as_paranoid/association_reflection.rb
@@ -2,6 +2,17 @@
 
 module ActsAsParanoid
   # Override for ActiveRecord::Reflection::AssociationReflection
+  #
+  # This makes automatic finding of inverse associations work where the
+  # inverse is a belongs_to association with the :with_deleted option set.
+  #
+  # Specifying :with_deleted for the belongs_to association would stop the
+  # inverse from being calculated because it sets scope where there was none,
+  # and normally an association having a scope means ActiveRecord will not
+  # automatically find the inverse association.
+  #
+  # This override adds an exception to that rule only for the case where the
+  # scope was added just to support the :with_deleted option.
   module AssociationReflection
     if ActiveRecord::VERSION::MAJOR < 7
       def can_find_inverse_of_automatically?(reflection)

--- a/lib/acts_as_paranoid/association_reflection.rb
+++ b/lib/acts_as_paranoid/association_reflection.rb
@@ -3,13 +3,28 @@
 module ActsAsParanoid
   # Override for ActiveRecord::Reflection::AssociationReflection
   module AssociationReflection
-    def scope_allows_automatic_inverse_of?(reflection, inverse_reflection)
-      if reflection.scope
+    if ActiveRecord::VERSION::MAJOR < 7
+      def can_find_inverse_of_automatically?(reflection)
         options = reflection.options
-        return true if options[:with_deleted] && !options.fetch(:original_scope)
-      end
 
-      super
+        if reflection.macro == :belongs_to && options[:with_deleted]
+          return false if options[:inverse_of] == false
+          return false if options[:foreign_key]
+
+          !options.fetch(:original_scope)
+        else
+          super
+        end
+      end
+    else
+      def scope_allows_automatic_inverse_of?(reflection, inverse_reflection)
+        if reflection.scope
+          options = reflection.options
+          return true if options[:with_deleted] && !options.fetch(:original_scope)
+        end
+
+        super
+      end
     end
   end
 end

--- a/lib/acts_as_paranoid/association_reflection.rb
+++ b/lib/acts_as_paranoid/association_reflection.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ActsAsParanoid
+  # Override for ActiveRecord::Reflection::AssociationReflection
+  module AssociationReflection
+    def scope_allows_automatic_inverse_of?(reflection, inverse_reflection)
+      if reflection.scope
+        options = reflection.options
+        return true if options[:with_deleted] && !options.fetch(:original_scope)
+      end
+
+      super
+    end
+  end
+end

--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -29,6 +29,10 @@ module ActsAsParanoid
 
       private
 
+      # NOTE: This breaks automatic finding of inverse_of because it sets scope
+      # where there was none.
+      # Specifically, it makes Reflection#scope_allows_automatic_inverse_of
+      # fail for the inverse reflection.
       def make_scope_with_deleted(scope)
         if scope
           old_scope = scope

--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -36,10 +36,6 @@ module ActsAsParanoid
 
       private
 
-      # NOTE: This breaks automatic finding of inverse_of because it sets scope
-      # where there was none.
-      # Specifically, it makes Reflection#scope_allows_automatic_inverse_of
-      # fail for the inverse reflection.
       def make_scope_with_deleted(scope)
         if scope
           old_scope = scope

--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -18,32 +18,38 @@ module ActsAsParanoid
         end
 
         with_deleted = options.delete(:with_deleted)
-        if with_deleted
-          if scope
-            old_scope = scope
-            scope = proc do |*args|
-              if old_scope.arity == 0
-                instance_exec(&old_scope).with_deleted
-              else
-                old_scope.call(*args).with_deleted
-              end
-            end
-          else
-            scope = proc do
-              if respond_to? :with_deleted
-                self.with_deleted
-              else
-                all
-              end
-            end
-          end
-        end
+        scope = make_scope_with_deleted(scope) if with_deleted
 
         result = belongs_to_without_deleted(target, scope, **options)
 
         result.values.last.options[:with_deleted] = with_deleted if with_deleted
 
         result
+      end
+
+      private
+
+      def make_scope_with_deleted(scope)
+        if scope
+          old_scope = scope
+          scope = proc do |*args|
+            if old_scope.arity == 0
+              instance_exec(&old_scope).with_deleted
+            else
+              old_scope.call(*args).with_deleted
+            end
+          end
+        else
+          scope = proc do
+            if respond_to? :with_deleted
+              with_deleted
+            else
+              all
+            end
+          end
+        end
+
+        scope
       end
     end
   end

--- a/lib/acts_as_paranoid/associations.rb
+++ b/lib/acts_as_paranoid/associations.rb
@@ -18,11 +18,18 @@ module ActsAsParanoid
         end
 
         with_deleted = options.delete(:with_deleted)
-        scope = make_scope_with_deleted(scope) if with_deleted
+        if with_deleted
+          original_scope = scope
+          scope = make_scope_with_deleted(scope)
+        end
 
         result = belongs_to_without_deleted(target, scope, **options)
 
-        result.values.last.options[:with_deleted] = with_deleted if with_deleted
+        if with_deleted
+          options = result.values.last.options
+          options[:with_deleted] = with_deleted
+          options[:original_scope] = original_scope
+        end
 
         result
       end

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -87,7 +87,6 @@ class AssociationsTest < ActiveSupport::TestCase
     has_many :paranoid_has_many_dependants, dependent: :destroy
     has_many :paranoid_booleans, dependent: :destroy
     has_many :not_paranoids, dependent: :delete_all
-    # has_many :paranoid_sections, dependent: :destroy
 
     has_one :has_one_not_paranoid, dependent: :destroy
 

--- a/test/test_associations.rb
+++ b/test/test_associations.rb
@@ -399,6 +399,13 @@ class AssociationsTest < ActiveSupport::TestCase
     assert_equal paranoid_parent, paranoid_parent.paranoid_children.first.paranoid_parent
   end
 
+  def test_belongs_to_with_deleted_as_inverse_of_has_many
+    has_many_reflection = ParanoidParent.reflect_on_association :paranoid_children
+    belongs_to_reflection = ParanoidChild.reflect_on_association :paranoid_parent
+
+    assert_equal belongs_to_reflection, has_many_reflection.inverse_of
+  end
+
   def test_belongs_to_polymorphic_with_deleted
     paranoid_time = ParanoidTime.create! name: "paranoid"
     paranoid_has_many_dependant = ParanoidHasManyDependant


### PR DESCRIPTION
The override of `belongs_to` creates a scope in the association where normally there would be none if the `:with_deleted` option is given. Having a scope in an association makes ActiveRecord refuse to automatically find an inverse relation. This change adds an override to make an exception if the scope was only added to support the `:with_deleted` option.

Fixes #232.