### PR TITLE
Update RuboCop and its configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.6
 
+Layout/LineContinuationLeadingSpace:
+  EnforcedStyle: leading
+
 # Be lenient with line length
 Layout/LineLength:
   Max: 92

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
   spec.add_development_dependency "rdoc", "~> 6.3"
-  spec.add_development_dependency "rubocop", "~> 1.25"
+  spec.add_development_dependency "rubocop", "~> 1.32"
   spec.add_development_dependency "rubocop-minitest", "~> 0.20.0"
   spec.add_development_dependency "simplecov", "~> 0.21.2"
 end


### PR DESCRIPTION
- Bump minimum RuboCop version
- Configure Layout/LineContinuationLeadingSpace
