### PR TITLE
Support JRuby 9.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,17 +19,19 @@ jobs:
 
     strategy:
       matrix:
-        ruby: [2.6, 2.7, "3.0", "3.1", jruby-9.3]
+        ruby: ["2.6", "2.7", "3.0", "3.1", jruby-9.3, jruby-9.4]
         gemfile: [active_record_52, active_record_60, active_record_61, active_record_70]
         exclude:
           # Rails 5.2 does not support Ruby 3.0
           - ruby: "3.0"
             gemfile: active_record_52
-          # Rails 5.2 does not support Ruby 3.1
+          # Rails 5.2 does not support Ruby 3.1 and JRuby 9.4 implements Ruby 3.1
           - ruby: "3.1"
             gemfile: active_record_52
-          # Rails 7.0 does not support Ruby 2.6 and jruby-9.3 is still depends on ruby 2.6
-          - ruby: 2.6
+          - ruby: "jruby-9.4"
+            gemfile: active_record_52
+          # Rails 7.0 does not support Ruby 2.6 and JRuby 9.3 implements Ruby 2.6
+          - ruby: "2.6"
             gemfile: active_record_70
           - ruby: jruby-9.3
             gemfile: active_record_70

--- a/Appraisals
+++ b/Appraisals
@@ -19,7 +19,7 @@ appraise "active_record_61" do
   gem "activesupport", "~> 6.1.0", require: "active_support"
 
   group :development do
-    gem "activerecord-jdbcsqlite3-adapter", "~> 61.0", platforms: [:jruby]
+    gem "activerecord-jdbcsqlite3-adapter", "~> 61.1", platforms: [:jruby]
   end
 end
 
@@ -28,6 +28,6 @@ appraise "active_record_70" do
   gem "activesupport", "~> 7.0.0", require: "active_support"
 
   group :development do
-    gem "activerecord-jdbcsqlite3-adapter", "~> 61.1", platforms: [:jruby]
+    gem "activerecord-jdbcsqlite3-adapter", "~> 70.0", platforms: [:jruby]
   end
 end

--- a/gemfiles/active_record_61.gemfile
+++ b/gemfiles/active_record_61.gemfile
@@ -8,7 +8,7 @@ gem "activerecord", "~> 6.1.0", require: "active_record"
 gem "activesupport", "~> 6.1.0", require: "active_support"
 
 group :development do
-  gem "activerecord-jdbcsqlite3-adapter", "~> 61.0", platforms: [:jruby]
+  gem "activerecord-jdbcsqlite3-adapter", "~> 61.1", platforms: [:jruby]
   gem "sqlite3", platforms: [:ruby]
 end
 

--- a/gemfiles/active_record_70.gemfile
+++ b/gemfiles/active_record_70.gemfile
@@ -8,7 +8,7 @@ gem "activerecord", "~> 7.0.0", require: "active_record"
 gem "activesupport", "~> 7.0.0", require: "active_support"
 
 group :development do
-  gem "activerecord-jdbcsqlite3-adapter", "~> 61.1", platforms: [:jruby]
+  gem "activerecord-jdbcsqlite3-adapter", "~> 70.0", platforms: [:jruby]
   gem "sqlite3", platforms: [:ruby]
 end
 


### PR DESCRIPTION
- Add JRuby 9.4 to the test matrix
- Update activerecord-jdbcsqlite3-adapter versions
