### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,25 +19,12 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", jruby-9.3, jruby-9.4]
-        gemfile: [active_record_52, active_record_60, active_record_61, active_record_70]
-        exclude:
-          # Rails 5.2 does not support Ruby 3.0
-          - ruby: "3.0"
+        ruby: ["2.7", "3.0", "3.1", "3.2", jruby-9.4]
+        gemfile: [active_record_60, active_record_61, active_record_70]
+        include:
+          # Rails 5.2 only works with Ruby 2.7 and below
+          - ruby: "2.7"
             gemfile: active_record_52
-          # Rails 5.2 does not support Ruby 3.1 and JRuby 9.4 implements Ruby 3.1
-          - ruby: "3.1"
-            gemfile: active_record_52
-          - ruby: "jruby-9.4"
-            gemfile: active_record_52
-          # Rails 5.2 does not support Ruby 3.2
-          - ruby: "3.2"
-            gemfile: active_record_52
-          # Rails 7.0 does not support Ruby 2.6 and JRuby 9.3 implements Ruby 2.6
-          - ruby: "2.6"
-            gemfile: active_record_70
-          - ruby: jruby-9.3
-            gemfile: active_record_70
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Layout/LineContinuationLeadingSpace:
   EnforcedStyle: leading

--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ recoverable later.
 
 ## Support
 
-**This branch targets Rails 5.2+ and Ruby 2.5+ only**
+**This version targets Rails 5.2+ and Ruby 2.7+ only**
 
-If you're working with Rails 5.1 and earlier, or with Ruby 2.4 or earlier,
-please switch to the corresponding branch or require an older version of the
-`acts_as_paranoid` gem.
+If you're working with Rails 5.1 and earlier, or with Ruby 2.6 or earlier,
+please require an older version of the `acts_as_paranoid` gem.
 
 ### Known issues
 

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description = "Check the home page for more in-depth information."
   spec.homepage = "https://github.com/ActsAsParanoid/acts_as_paranoid"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["rubygems_mfa_required"] = "true"
 


### PR DESCRIPTION
- Drop support for Ruby 2.6
- Update support information in README
