### PR TITLE
Support Ruby 3.0 and up

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", jruby-9.4]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "jruby-9.4"]
         gemfile: [active_record_61, active_record_70, active_record_71]
         exclude:
           # The activerecord-jdbcsqlite3-adapter gem does not work with Rails 7.1 yet

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description = "Check the home page for more in-depth information."
   spec.homepage = "https://github.com/ActsAsParanoid/acts_as_paranoid"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["rubygems_mfa_required"] = "true"
 


### PR DESCRIPTION
- Drop support for Ruby 2.7
- Build with Rubies 3.0 through 3.3 in CI
