### PR TITLE
Use correct sqlite3 versions in tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 # Development dependencies
 group :development do
   gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
-  gem "sqlite3", platforms: [:ruby]
+  gem "sqlite3", "~> 1.4", platforms: [:ruby]
 end
 
 gemspec

--- a/gemfiles/active_record_61.gemfile
+++ b/gemfiles/active_record_61.gemfile
@@ -9,7 +9,7 @@ gem "activesupport", "~> 6.1.0", require: "active_support"
 
 group :development do
   gem "activerecord-jdbcsqlite3-adapter", "~> 61.1", platforms: [:jruby]
-  gem "sqlite3", platforms: [:ruby]
+  gem "sqlite3", "~> 1.4", platforms: [:ruby]
 end
 
 gemspec path: "../"

--- a/gemfiles/active_record_70.gemfile
+++ b/gemfiles/active_record_70.gemfile
@@ -9,7 +9,7 @@ gem "activesupport", "~> 7.0.0", require: "active_support"
 
 group :development do
   gem "activerecord-jdbcsqlite3-adapter", "~> 70.0", platforms: [:jruby]
-  gem "sqlite3", platforms: [:ruby]
+  gem "sqlite3", "~> 1.4", platforms: [:ruby]
 end
 
 gemspec path: "../"

--- a/gemfiles/active_record_71.gemfile
+++ b/gemfiles/active_record_71.gemfile
@@ -9,7 +9,7 @@ gem "activesupport", "~> 7.1.0", require: "active_support"
 
 group :development do
   gem "activerecord-jdbcsqlite3-adapter", "~> 70.0", platforms: [:jruby]
-  gem "sqlite3", platforms: [:ruby]
+  gem "sqlite3", "~> 1.4", platforms: [:ruby]
 end
 
 gemspec path: "../"


### PR DESCRIPTION
We do not specify the exact `sqlite3` version in the Gemfiles. Recently, the `sqlite3` v2 was released, but rails wants `~> 1.4`.