### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.0.0"
 
+  spec.metadata["changelog_uri"] = "https://github.com/ActsAsParanoid/acts_as_paranoid/blob/master/CHANGELOG.md"
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.files = File.read("Manifest.txt").split


### PR DESCRIPTION
Supported here: https://guides.rubygems.org/specification-reference/#metadata  Useful for running https://github.com/MaximeD/gem_updater