### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.files = File.read("Manifest.txt").split
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", ">= 6.1", "< 7.2"
-  spec.add_runtime_dependency "activesupport", ">= 6.1", "< 7.2"
+  spec.add_dependency "activerecord", ">= 6.1", "< 7.2"
+  spec.add_dependency "activesupport", ">= 6.1", "< 7.2"
 
   spec.add_development_dependency "appraisal", "~> 2.3"
   spec.add_development_dependency "minitest", "~> 5.14"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
