### PR TITLE
Loosen sqlite3 development dependency

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -15,6 +15,7 @@ appraise "active_record_61" do
 
   group :development do
     gem "activerecord-jdbcsqlite3-adapter", "~> 61.1", platforms: [:jruby]
+    gem "sqlite3", "~> 1.4", platforms: [:ruby]
   end
 end
 
@@ -24,6 +25,7 @@ appraise "active_record_70" do
 
   group :development do
     gem "activerecord-jdbcsqlite3-adapter", "~> 70.0", platforms: [:jruby]
+    gem "sqlite3", "~> 1.4", platforms: [:ruby]
   end
 end
 
@@ -32,7 +34,7 @@ appraise "active_record_71" do
   gem "activesupport", "~> 7.1.0", require: "active_support"
 
   group :development do
-    gem "activerecord-jdbcsqlite3-adapter", "~> 70.0", platforms: [:jruby]
+    gem "sqlite3", "~> 1.4", platforms: [:ruby]
   end
 end
 
@@ -41,6 +43,6 @@ appraise "active_record_72" do
   gem "activesupport", "~> 7.2.0", require: "active_support"
 
   group :development do
-    gem "activerecord-jdbcsqlite3-adapter", "~> 70.0", platforms: [:jruby]
+    gem "sqlite3", "~> 2.0.0", platforms: [:ruby]
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 # Development dependencies
 group :development do
   gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
-  gem "sqlite3", "~> 1.4", platforms: [:ruby]
+  gem "sqlite3", ">= 1.4", "<= 2.1", platforms: [:ruby]
 end
 
 gemspec

--- a/gemfiles/active_record_71.gemfile
+++ b/gemfiles/active_record_71.gemfile
@@ -8,7 +8,7 @@ gem "activerecord", "~> 7.1.0", require: "active_record"
 gem "activesupport", "~> 7.1.0", require: "active_support"
 
 group :development do
-  gem "activerecord-jdbcsqlite3-adapter", "~> 70.0", platforms: [:jruby]
+  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
   gem "sqlite3", "~> 1.4", platforms: [:ruby]
 end
 

--- a/gemfiles/active_record_72.gemfile
+++ b/gemfiles/active_record_72.gemfile
@@ -8,8 +8,8 @@ gem "activerecord", "~> 7.2.0", require: "active_record"
 gem "activesupport", "~> 7.2.0", require: "active_support"
 
 group :development do
-  gem "activerecord-jdbcsqlite3-adapter", "~> 70.0", platforms: [:jruby]
-  gem "sqlite3", "~> 1.4", platforms: [:ruby]
+  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+  gem "sqlite3", "~> 2.0.0", platforms: [:ruby]
 end
 
 gemspec path: "../"


### PR DESCRIPTION
Allow version 2.0 for the sqlite3 gem for testing with Rails 7.2
