### PR TITLE
Fix CI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ActsAsParanoid
 
-[![Build Status](https://travis-ci.org/ActsAsParanoid/acts_as_paranoid.png?branch=master)](https://travis-ci.org/ActsAsParanoid/acts_as_paranoid)
+[![CI](https://github.com/ActsAsParanoid/acts_as_paranoid/actions/workflows/ruby.yml/badge.svg)](https://github.com/ActsAsParanoid/acts_as_paranoid/actions/workflows/ruby.yml)
 
 A Rails plugin to add soft delete.
 


### PR DESCRIPTION
Use GitHub Action's badge

### Before

![image](https://github.com/user-attachments/assets/979aca3e-be5d-4db5-ad7a-07b49f409e76)

### After

![image](https://github.com/user-attachments/assets/028718d1-fbbc-47d1-b182-f32e24f0d20d)
