### PR TITLE
Support Rails 8.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -21,17 +21,29 @@ jobs:
     strategy:
       matrix:
         ruby: ["3.0", "3.1", "3.2", "3.3", "jruby-9.4"]
-        gemfile: [active_record_61, active_record_70, active_record_71, active_record_72]
+        gemfile:
+          - active_record_61
+          - active_record_70
+          - active_record_71
+          - active_record_72
+          - active_record_80
         exclude:
-          # The activerecord-jdbcsqlite3-adapter gem does not work with Rails 7.1 yet
+          # The activerecord-jdbcsqlite3-adapter gem does not work with Rails
+          # 7.1 and above yet
           - ruby: "jruby-9.4"
             gemfile: active_record_71
-          # The activerecord-jdbcsqlite3-adapter gem does not work with Rails 7.2 yet
           - ruby: "jruby-9.4"
             gemfile: active_record_72
+          - ruby: "jruby-9.4"
+            gemfile: active_record_80
           # Rails 7.2 requires Ruby 3.1
           - ruby: "3.0"
             gemfile: active_record_72
+          # Rails 8.0 requires Ruby 3.2
+          - ruby: "3.0"
+            gemfile: active_record_80
+          - ruby: "3.1"
+            gemfile: active_record_80
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/Appraisals
+++ b/Appraisals
@@ -43,6 +43,15 @@ appraise "active_record_72" do
   gem "activesupport", "~> 7.2.0", require: "active_support"
 
   group :development do
-    gem "sqlite3", "~> 2.0.0", platforms: [:ruby]
+    gem "sqlite3", "~> 2.0", platforms: [:ruby]
+  end
+end
+
+appraise "active_record_80" do
+  gem "activerecord", "~> 8.0.0", require: "active_record"
+  gem "activesupport", "~> 8.0.0", require: "active_support"
+
+  group :development do
+    gem "sqlite3", "~> 2.0", platforms: [:ruby]
   end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 # Development dependencies
 group :development do
-  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
   gem "sqlite3", ">= 1.4", "<= 2.1", platforms: [:ruby]
 end
 

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.files = File.read("Manifest.txt").split
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 6.1", "< 8"
-  spec.add_dependency "activesupport", ">= 6.1", "< 8"
+  spec.add_dependency "activerecord", ">= 6.1", "< 8.1"
+  spec.add_dependency "activesupport", ">= 6.1", "< 8.1"
 
   spec.add_development_dependency "appraisal", "~> 2.3"
   spec.add_development_dependency "minitest", "~> 5.14"

--- a/gemfiles/active_record_71.gemfile
+++ b/gemfiles/active_record_71.gemfile
@@ -8,7 +8,6 @@ gem "activerecord", "~> 7.1.0", require: "active_record"
 gem "activesupport", "~> 7.1.0", require: "active_support"
 
 group :development do
-  gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
   gem "sqlite3", "~> 1.4", platforms: [:ruby]
 end
 

--- a/gemfiles/active_record_80.gemfile
+++ b/gemfiles/active_record_80.gemfile
@@ -4,8 +4,8 @@
 
 source "https://rubygems.org"
 
-gem "activerecord", "~> 7.2.0", require: "active_record"
-gem "activesupport", "~> 7.2.0", require: "active_support"
+gem "activerecord", "~> 8.0.0", require: "active_record"
+gem "activesupport", "~> 8.0.0", require: "active_support"
 
 group :development do
   gem "sqlite3", "~> 2.0", platforms: [:ruby]


### PR DESCRIPTION
This change updates acts_as_paranoid's dependencies to allow activerecord and activesupport version 8.0.

No functional changes are needed.

- Update acts_as_paranoid's dependencies on activerecord and activesupport to allow version 8.0
- Remove activerecord-jdbcsqlite3-adapter dependency to allow Bundler to consider activerecord 8.0
- Add an appraisal for activerecord 8.0
- Update GitHub Actions configuration to test with the new active_record_80 appraisal
