### PR TITLE
Support Ruby 3.1 through 3.4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.0", "3.1", "3.2", "3.3", "jruby-9.4"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "jruby-9.4"]
         gemfile:
           - active_record_61
           - active_record_70
@@ -36,12 +36,7 @@ jobs:
             gemfile: active_record_72
           - ruby: "jruby-9.4"
             gemfile: active_record_80
-          # Rails 7.2 requires Ruby 3.1
-          - ruby: "3.0"
-            gemfile: active_record_72
           # Rails 8.0 requires Ruby 3.2
-          - ruby: "3.0"
-            gemfile: active_record_80
           - ruby: "3.1"
             gemfile: active_record_80
 
@@ -67,7 +62,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop -P

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -39,6 +39,11 @@ jobs:
           # Rails 8.0 requires Ruby 3.2
           - ruby: "3.1"
             gemfile: active_record_80
+          # Rails 6.1 and 7.0 do not support Ruby 3.4
+          - ruby: "3.4"
+            gemfile: active_record_61
+          - ruby: "3.4"
+            gemfile: active_record_70
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ require:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/acts_as_paranoid.gemspec
+++ b/acts_as_paranoid.gemspec
@@ -13,8 +13,9 @@ Gem::Specification.new do |spec|
   spec.description = "Check the home page for more in-depth information."
   spec.homepage = "https://github.com/ActsAsParanoid/acts_as_paranoid"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
+  spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["changelog_uri"] = "https://github.com/ActsAsParanoid/acts_as_paranoid/blob/master/CHANGELOG.md"
   spec.metadata["rubygems_mfa_required"] = "true"
 


### PR DESCRIPTION
This drops support for Ruby 3.0 which is EOL.
